### PR TITLE
Add support for aws profiles

### DIFF
--- a/examples/aws/example-build/backend.tf
+++ b/examples/aws/example-build/backend.tf
@@ -2,8 +2,11 @@
 terraform {
   backend "s3" {
     bucket         = "<cluster name>-state"
-    key            = "terraform.tfstate"
-    region         = "<aws region>"
     dynamodb_table = "<cluster name>-lock"
+    key            = "terraform.tfstate"
+
+    # Make sure to define profile in ~/.aws/config
+    profile = "<cluster name>"
+    region  = "<aws region>"
   }
 }

--- a/examples/aws/example-build/profile.tf
+++ b/examples/aws/example-build/profile.tf
@@ -1,0 +1,5 @@
+# Replace <cluster name> with proper values.
+provider "aws" {
+  # Make sure to define profile in ~/.aws/config
+  profile = "<cluster name>"
+}

--- a/platforms/aws/giantnetes/provider.tf
+++ b/platforms/aws/giantnetes/provider.tf
@@ -1,0 +1,1 @@
+../../../build/provider.tf


### PR DESCRIPTION
this allows to use AWS profiles. Including case with assume role.

Only limitation kind of we need to agree that we will define profiles with codename of the clusters. Not with the name of the customer as we are doing at the moment.