### PR TITLE
Change default worker size in Azure

### DIFF
--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -78,7 +78,7 @@ variable "master_storage_type" {
 
 variable "worker_vm_size" {
   type    = "string"
-  default = "Standard_DS2_v2"
+  default = "Standard_DS3_v2"
 }
 
 variable "worker_storage_type" {


### PR DESCRIPTION
We need thick worker VMs in Azure in order to host ELK stack. Standard_DS3_v2 is similar to m4.xlarge in aws.