### PR TITLE
Ignore terraform changes for Vault and kubernetes PVs

### DIFF
--- a/modules/azure/vault/vault.tf
+++ b/modules/azure/vault/vault.tf
@@ -14,6 +14,12 @@ resource "azurerm_virtual_machine" "vault" {
   network_interface_ids = ["${var.network_interface_ids[0]}"]
   vm_size               = "${var.vm_size}"
 
+  lifecycle {
+    # Vault provisioned also by Ansible,
+    # so prevent recreation if user_data or ami changed.
+    ignore_changes = ["ami", "user_data"]
+  }
+
   delete_os_disk_on_termination = true
 
   delete_data_disks_on_termination = false

--- a/modules/azure/worker-as/worker-as.tf
+++ b/modules/azure/worker-as/worker-as.tf
@@ -32,6 +32,11 @@ resource "azurerm_virtual_machine" "worker" {
   availability_set_id   = "${azurerm_availability_set.workers.id}"
   vm_size               = "${var.vm_size}"
 
+  lifecycle {
+    # Workaround to ignore Kubernetes-managed persistent volumes.
+    ignore_changes = ["storage_data_disk"]
+  }
+
   delete_os_disk_on_termination = true
 
   delete_data_disks_on_termination = true


### PR DESCRIPTION
Right now `terraform apply` detects Kubernetes managed volumes as a change. Also make sure we are not recreating Vault if new CoreOS version was released.