### PR TITLE
Use protocol 4 for IPIP

### DIFF
--- a/modules/aws/master/master.tf
+++ b/modules/aws/master/master.tf
@@ -97,7 +97,7 @@ resource "aws_security_group" "master" {
   ingress {
     from_port   = 0
     to_port     = 0
-    protocol    = 94
+    protocol    = 4
     cidr_blocks = ["${var.vpc_cidr}"]
   }
 

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -117,7 +117,7 @@ resource "aws_security_group" "worker" {
   ingress {
     from_port   = 0
     to_port     = 0
-    protocol    = 94
+    protocol    = 4
     cidr_blocks = ["${var.vpc_cidr}"]
   }
 


### PR DESCRIPTION
In calico slack they recommended to use protocol 4 instead of 94 in security groups.

Unfortunately i can not confirm that it fixes the IPIP tunnels problem, but at least this does not break anything. All last roll outs done with this change.