### PR TITLE
Use new tagging for AWS

### DIFF
--- a/modules/aws/bastion/bastion.tf
+++ b/modules/aws/bastion/bastion.tf
@@ -23,8 +23,8 @@ resource "aws_instance" "bastion" {
   user_data = "${var.user_data}"
 
   tags = {
-    Name        = "${var.cluster_name}-bastion${count.index}"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-bastion${count.index}"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 
@@ -66,8 +66,8 @@ resource "aws_security_group" "bastion" {
   }
 
   tags {
-    Name        = "${var.cluster_name}-bastion"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-bastion"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 

--- a/modules/aws/dns/dns.tf
+++ b/modules/aws/dns/dns.tf
@@ -14,8 +14,8 @@ resource "aws_route53_zone" "public" {
   name = "${var.zone_name}"
 
   tags {
-    Name        = "${var.zone_name}"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.zone_name}"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 

--- a/modules/aws/master/master-elb.tf
+++ b/modules/aws/master/master-elb.tf
@@ -21,10 +21,12 @@ resource "aws_elb" "master" {
     interval            = 15
   }
 
-  tags {
-    Name        = "${var.cluster_name}-master"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-master"
+    )
+  )}"
 }
 
 resource "aws_elb_attachment" "master" {
@@ -50,10 +52,12 @@ resource "aws_security_group" "master_elb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
-    Name        = "${var.cluster_name}-master-elb"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-master-elb"
+    )
+  )}"
 }
 
 resource "aws_route53_record" "master-api" {

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -1,12 +1,21 @@
+locals {
+  common_tags = "${map(
+    "giantswarm.io/installation", "${var.cluster_name}",
+    "kubernetes.io/cluster/${var.cluster_name}", "owned"
+  )}"
+}
+
 resource "aws_s3_bucket" "ignition" {
   bucket        = "${var.aws_account}-${var.cluster_name}-ignition"
   acl           = "private"
   force_destroy = true
 
-  tags {
-    Name        = "${var.cluster_name}-ignition"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-ignition"
+    )
+  )}"
 }
 
 output "ignition_bucket_id" {

--- a/modules/aws/vault/vault-elb.tf
+++ b/modules/aws/vault/vault-elb.tf
@@ -20,8 +20,8 @@ resource "aws_elb" "vault" {
   }
 
   tags {
-    Name        = "${var.cluster_name}-vault"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-vault"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 
@@ -49,8 +49,8 @@ resource "aws_security_group" "vault_elb" {
   }
 
   tags {
-    Name        = "${var.cluster_name}-vault-elb"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-vault-elb"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 

--- a/modules/aws/vault/vault.tf
+++ b/modules/aws/vault/vault.tf
@@ -24,8 +24,8 @@ resource "aws_instance" "vault" {
   user_data = "${var.user_data}"
 
   tags = {
-    Name        = "${var.cluster_name}-vault${count.index}"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-vault${count.index}"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 
@@ -35,8 +35,8 @@ resource "aws_ebs_volume" "vault_etcd" {
   type              = "${var.volume_type}"
 
   tags {
-    Name        = "${var.cluster_name}-vault"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-vault"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 
@@ -78,8 +78,8 @@ resource "aws_security_group" "vault" {
   }
 
   tags {
-    Name        = "${var.cluster_name}-vault"
-    Environment = "${var.cluster_name}"
+    Name                         = "${var.cluster_name}-vault"
+    "giantswarm.io/installation" = "${var.cluster_name}"
   }
 }
 

--- a/modules/aws/vpc/vpc-subnet-bastion.tf
+++ b/modules/aws/vpc/vpc-subnet-bastion.tf
@@ -3,10 +3,12 @@ resource "aws_subnet" "bastion_0" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "${var.subnet_bastion_0}"
 
-  tags {
-    Name        = "${var.cluster_name}-bastion0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-bastion0"
+    )
+  )}"
 }
 
 resource "aws_subnet" "bastion_1" {
@@ -14,10 +16,12 @@ resource "aws_subnet" "bastion_1" {
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "${var.subnet_bastion_1}"
 
-  tags {
-    Name        = "${var.cluster_name}-bastion1"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-bastion1"
+    )
+  )}"
 }
 
 resource "aws_route_table_association" "bastion_0" {

--- a/modules/aws/vpc/vpc-subnet-elb.tf
+++ b/modules/aws/vpc/vpc-subnet-elb.tf
@@ -3,10 +3,12 @@ resource "aws_subnet" "elb_0" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "${var.subnet_elb_0}"
 
-  tags {
-    Name        = "${var.cluster_name}-elb0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-elb0"
+    )
+  )}"
 }
 
 resource "aws_subnet" "elb_1" {
@@ -14,10 +16,12 @@ resource "aws_subnet" "elb_1" {
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "${var.subnet_elb_1}"
 
-  tags {
-    Name        = "${var.cluster_name}-elb1"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-elb1"
+    )
+  )}"
 }
 
 resource "aws_route_table_association" "elb_0" {

--- a/modules/aws/vpc/vpc-subnet-vault.tf
+++ b/modules/aws/vpc/vpc-subnet-vault.tf
@@ -3,10 +3,12 @@ resource "aws_subnet" "vault_0" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "${var.subnet_vault_0}"
 
-  tags {
-    Name        = "${var.cluster_name}-vault0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-vault0"
+    )
+  )}"
 }
 
 resource "aws_route_table_association" "vault_0" {

--- a/modules/aws/vpc/vpc-subnet-worker.tf
+++ b/modules/aws/vpc/vpc-subnet-worker.tf
@@ -3,10 +3,12 @@ resource "aws_subnet" "worker_0" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "${var.subnet_worker_0}"
 
-  tags {
-    Name        = "${var.cluster_name}-worker0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-worker0"
+    )
+  )}"
 }
 
 resource "aws_subnet" "worker_1" {
@@ -14,10 +16,12 @@ resource "aws_subnet" "worker_1" {
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "${var.subnet_worker_1}"
 
-  tags {
-    Name        = "${var.cluster_name}-worker1"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-worker1"
+    )
+  )}"
 }
 
 resource "aws_route_table_association" "worker_0" {

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -6,6 +6,13 @@
 #   * vault and worker subnets are using the private route table
 #   * the private nat gateway is in the bastion subnet as well (needs to be in a public subnet)
 
+locals {
+  common_tags = "${map(
+    "giantswarm.io/installation", "${var.cluster_name}",
+    "kubernetes.io/cluster/${var.cluster_name}", "owned"
+  )}"
+}
+
 data "aws_availability_zones" "available" {}
 
 data "aws_region" "current" {}
@@ -16,19 +23,23 @@ resource "aws_vpc" "cluster_vpc" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags {
-    Name        = "${var.cluster_name}"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}"
+    )
+  )}"
 }
 
 resource "aws_internet_gateway" "cluster_vpc" {
   vpc_id = "${aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name        = "${var.cluster_name}"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}"
+    )
+  )}"
 }
 
 resource "aws_nat_gateway" "private_nat_gateway_0" {
@@ -44,55 +55,67 @@ resource "aws_nat_gateway" "private_nat_gateway_1" {
 resource "aws_eip" "private_nat_gateway_0" {
   vpc = true
 
-  tags {
-    Name        = "${var.cluster_name}-private-nat-gateway0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-private-nat-gateway0"
+    )
+  )}"
 }
 
 resource "aws_eip" "private_nat_gateway_1" {
   vpc = true
 
-  tags {
-    Name        = "${var.cluster_name}-private-nat-gateway1"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-private-nat-gateway1"
+    )
+  )}"
 }
 
 resource "aws_route_table" "cluster_vpc_private_0" {
   vpc_id = "${aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name        = "${var.cluster_name}_private_0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}_private_0"
+    )
+  )}"
 }
 
 resource "aws_route_table" "cluster_vpc_private_1" {
   vpc_id = "${aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name        = "${var.cluster_name}_private_1"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}_private_1"
+    )
+  )}"
 }
 
 resource "aws_route_table" "cluster_vpc_public_0" {
   vpc_id = "${aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name        = "${var.cluster_name}-public0"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-public0"
+    )
+  )}"
 }
 
 resource "aws_route_table" "cluster_vpc_public_1" {
   vpc_id = "${aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name        = "${var.cluster_name}-public1"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-public1"
+    )
+  )}"
 }
 
 resource "aws_route" "vpc_local_route_0" {

--- a/modules/aws/vpn/vpn.tf
+++ b/modules/aws/vpn/vpn.tf
@@ -1,5 +1,6 @@
 # site2site vpn for access to bastion
 
+variable "aws_cluster_name" {}
 variable "aws_customer_gateway_id" {}
 variable "aws_external_ipsec_subnet" {}
 variable "aws_vpn_name" {}
@@ -14,8 +15,8 @@ resource "aws_vpn_gateway" "vpn_gw" {
   vpc_id = "${var.aws_vpn_vpc_id}"
 
   tags {
-    Name        = "${var.aws_vpn_name}"
-    Environment = "${var.aws_vpn_name}"
+    Name                         = "${var.aws_vpn_name}"
+    "giantswarm.io/installation" = "${var.aws_cluster_name}"
   }
 }
 
@@ -27,8 +28,8 @@ resource "aws_vpn_connection" "aws_vpn_conn" {
   static_routes_only  = true
 
   tags {
-    Name        = "${var.aws_vpn_name}"
-    Environment = "${var.aws_vpn_name}"
+    Name                         = "${var.aws_vpn_name}"
+    "giantswarm.io/installation" = "${var.aws_cluster_name}"
   }
 }
 

--- a/modules/aws/worker-asg/worker-elb.tf
+++ b/modules/aws/worker-asg/worker-elb.tf
@@ -27,10 +27,12 @@ resource "aws_elb" "worker" {
     interval            = 15
   }
 
-  tags {
-    Name        = "${var.cluster_name}-worker"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-worker"
+    )
+  )}"
 }
 
 resource "aws_proxy_protocol_policy" "worker" {
@@ -63,10 +65,12 @@ resource "aws_security_group" "worker_elb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
-    Name        = "${var.cluster_name}-worker-elb"
-    Environment = "${var.cluster_name}"
-  }
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-worker-elb"
+    )
+  )}"
 }
 
 resource "aws_route53_record" "worker-wildcard" {

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -210,6 +210,7 @@ module "vpn" {
 
   # If aws_customer_gateway_id is not set, no vpn resources will be created.
   aws_customer_gateway_id    = "${var.aws_customer_gateway_id}"
+  aws_cluster_name           = "${var.cluster_name}"
   aws_external_ipsec_subnet  = "${var.external_ipsec_subnet}"
   aws_public_route_table_ids = "${module.vpc.public_route_table_ids}"
   aws_vpn_name               = "Giant Swarm <-> ${var.cluster_name}"


### PR DESCRIPTION
New tags:
- giantswarm.io/installation=CLUSTER_NAME
- kubernetes.io/cluster/CLUSTER_NAME=owned

Instead of:
- Environment=CLUSTER_NAME
- KubernetesCluster=CLUSTER_NAME

Terraform does not support interpolation for tag name that's why such ugly constructions are used. See bug https://github.com/hashicorp/terraform/issues/14516