### PR TITLE
Remove docker flag disable legacy registy

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -1833,7 +1833,7 @@ coreos:
         [Service]
         Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=50m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
         Environment="DOCKER_OPT_BIP=--bip=${DOCKER_CIDR}"
-        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false --disable-legacy-registry=true"
+        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false"
   - name: k8s-setup-network-env.service
     enable: true
     command: start

--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -2109,7 +2109,7 @@ coreos:
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/bin/sh -c "/usr/bin/docker run --rm --pid=host --net=host --privileged=true \
-      -v /:/rootfs:ro,shared \
+      -v /:/rootfs:ro,rshared \
       -v /sys:/sys:ro \
       -v /dev:/dev:rw \
       -v /run/calico/:/run/calico/:rw \
@@ -2118,8 +2118,8 @@ coreos:
       -v /var/log:/var/log:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
-      -v /var/lib/docker/:/var/lib/docker:rw,shared \
-      -v /var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+      -v /var/lib/docker/:/var/lib/docker:rw,rshared \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
       -v /etc/cni/net.d/:/etc/cni/net.d/ \

--- a/cloud-config/worker.yaml.tmpl
+++ b/cloud-config/worker.yaml.tmpl
@@ -546,7 +546,7 @@ coreos:
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/bin/sh -c "/usr/bin/docker run --rm --pid=host --net=host --privileged=true \
-      -v /:/rootfs:ro,shared \
+      -v /:/rootfs:ro,rshared \
       -v /sys:/sys:ro \
       -v /dev:/dev:rw \
       -v /run/calico/:/run/calico/:rw \
@@ -554,8 +554,8 @@ coreos:
       -v /run/docker.sock:/run/docker.sock:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
-      -v /var/lib/docker/:/var/lib/docker:rw,shared \
-      -v /var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+      -v /var/lib/docker/:/var/lib/docker:rw,rshared \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
       -v /var/log:/var/log:rw \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \

--- a/cloud-config/worker.yaml.tmpl
+++ b/cloud-config/worker.yaml.tmpl
@@ -401,7 +401,7 @@ coreos:
         [Service]
         Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=50m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
         Environment="DOCKER_OPT_BIP=--bip=${DOCKER_CIDR}"
-        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false --disable-legacy-registry=true"
+        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false"
   - name: k8s-setup-network-env.service
     enable: true
     command: start

--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -1945,7 +1945,7 @@ systemd:
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/bin/sh -c "/usr/bin/docker run --rm --pid=host --net=host --privileged=true \
-      -v /:/rootfs:ro,shared \
+      -v /:/rootfs:ro,rshared \
       -v /sys:/sys:ro \
       -v /dev:/dev:rw \
       -v /run/calico/:/run/calico/:rw \
@@ -1954,8 +1954,8 @@ systemd:
       -v /var/log:/var/log:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
-      -v /var/lib/docker/:/var/lib/docker:rw,shared \
-      -v /var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+      -v /var/lib/docker/:/var/lib/docker:rw,rshared \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
       -v /etc/cni/net.d/:/etc/cni/net.d/ \

--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -1675,7 +1675,7 @@ systemd:
         [Service]
         Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=50m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
         Environment="DOCKER_OPT_BIP=--bip=${DOCKER_CIDR}"
-        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false --disable-legacy-registry=true"
+        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false"
   - name: k8s-setup-network-env.service
     enabled: true
     contents: |

--- a/ignition/aws/worker.yaml.tmpl
+++ b/ignition/aws/worker.yaml.tmpl
@@ -396,7 +396,7 @@ systemd:
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/bin/sh -c "/usr/bin/docker run --rm --pid=host --net=host --privileged=true \
-      -v /:/rootfs:ro,shared \
+      -v /:/rootfs:ro,rshared \
       -v /sys:/sys:ro \
       -v /dev:/dev:rw \
       -v /run/calico/:/run/calico/:rw \
@@ -404,8 +404,8 @@ systemd:
       -v /run/docker.sock:/run/docker.sock:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
-      -v /var/lib/docker/:/var/lib/docker:rw,shared \
-      -v /var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+      -v /var/lib/docker/:/var/lib/docker:rw,rshared \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
       -v /var/log:/var/log:rw \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \

--- a/ignition/aws/worker.yaml.tmpl
+++ b/ignition/aws/worker.yaml.tmpl
@@ -242,7 +242,7 @@ systemd:
         [Service]
         Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=50m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
         Environment="DOCKER_OPT_BIP=--bip=${DOCKER_CIDR}"
-        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false --disable-legacy-registry=true"
+        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false --icc=false"
   - name: k8s-setup-network-env.service
     enabled: true
     contents: |


### PR DESCRIPTION
New docker does not have this flag and legacy registry support.

This change is compatible with prev docker version.

Also update `shared` to `rshared`, because new docker forces it.

```
must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: "/var/lib/docker", bind mount source: "/", propagation: "shared".
```

From [official documentation](https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation) `rshared` is 

```
The same as shared, but the propagation also extends to and from mount points nested within any of the original or replica mount points.
```

