### PR TITLE
Properly disable wait online service

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -2164,6 +2164,8 @@ coreos:
     command: stop
     mask: true
   - name: systemd-networkd-wait-online.service
+    enable: false
+    command: stop
     mask: true
   - name: api-certs.service
     enable: true

--- a/cloud-config/worker.yaml.tmpl
+++ b/cloud-config/worker.yaml.tmpl
@@ -387,6 +387,8 @@ coreos:
     command: stop
     mask: true
   - name: systemd-networkd-wait-online.service
+    enable: false
+    command: stop
     mask: true
   - name: docker.service
     enable: true


### PR DESCRIPTION
due to cloud-config specifics we need to stop service also, because cloud-config applied later and service already was started.