### PR TITLE
Disable etcd3-defragmentation service

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -2011,8 +2011,7 @@ coreos:
       [Install]
       WantedBy=multi-user.target
   - name: etcd3-defragmentation.service
-    enable: true
-    command: start
+    enable: false
     content: |
       [Unit]
       Description=etcd defragmentation job


### PR DESCRIPTION
We manage this service by timer, so we don't want it to be started on boot. Starting it on boot causes race conditions sometimes, because systemd will start etcd3-defragmentation immediately after etcd3, so etcd3 was not be able to start.

ignition already has this service disabled.