### PR TITLE
Update CoreDNS

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -648,7 +648,8 @@ write_files:
             health
             kubernetes cluster.local ${K8S_SERVICE_CIDR} ${POD_CIDR} {
               pods insecure
-              upstream /etc/resolv.conf
+              upstream
+              fallthrough in-addr.arpa ip6.arpa
             }
             prometheus :9153
             proxy . /etc/resolv.conf
@@ -695,7 +696,7 @@ write_files:
                   topologyKey: kubernetes.io/hostname
           containers:
           - name: coredns
-            image: coredns/coredns:1.0.5
+            image: coredns/coredns:1.1.1
             imagePullPolicy: IfNotPresent
             args: [ "-conf", "/etc/coredns/Corefile" ]
             volumeMounts:

--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -452,7 +452,8 @@ storage:
                   health
                   kubernetes cluster.local ${K8S_SERVICE_CIDR} ${CALICO_CIDR} {
                     pods insecure
-                    upstream /etc/resolv.conf
+                    upstream
+                    fallthrough in-addr.arpa ip6.arpa
                   }
                   prometheus :9153
                   proxy . /etc/resolv.conf
@@ -513,7 +514,7 @@ storage:
                         topologyKey: kubernetes.io/hostname
                 containers:
                 - name: coredns
-                  image: coredns/coredns:1.0.5
+                  image: coredns/coredns:1.1.1
                   imagePullPolicy: IfNotPresent
                   args: [ "-conf", "/etc/coredns/Corefile" ]
                   volumeMounts:


### PR DESCRIPTION
There was [regression](https://github.com/coredns/coredns/issues/1532) in CoreDNS that caused broken e2e conformance tests for DNS [here](https://github.com/giantswarm/giantnetes-terraform/pull/68#issuecomment-381061326).

Tested in `gauss`.