### PR TITLE
Changes, required for China region

### DIFF
--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -2201,6 +2201,7 @@ systemd:
       --cluster-dns=${K8S_DNS_IP} \
       --cluster-domain=cluster.local \
       --network-plugin=cni \
+      --pod-infra-container-image=${POD_INFRA_IMAGE} \
       --feature-gates=ExpandPersistentVolumes=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --register-node=true \

--- a/ignition/aws/worker.yaml.tmpl
+++ b/ignition/aws/worker.yaml.tmpl
@@ -412,6 +412,7 @@ systemd:
       --cluster-dns=${K8S_DNS_IP} \
       --cluster-domain=cluster.local \
       --network-plugin=cni \
+      --pod-infra-container-image=${POD_INFRA_IMAGE} \
       --register-node=true \
       --allow-privileged=true \
       --feature-gates=ExpandPersistentVolumes=true \

--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -216,7 +216,6 @@ stage-destroy() {
   cd ${BUILDDIR}
 
   source envs.sh
-  sleep 600
   terraform init ../platforms/aws/giantnetes
   terraform destroy -force ../platforms/aws/giantnetes
 
@@ -233,7 +232,7 @@ stage-wait-kubernetes-nodes(){
     until [ ${nodes_num_expected} -eq ${nodes_num_actual} ]; do
         msg "Waiting all nodes to be ready."
         sleep 30; let tries+=1;
-        [ ${tries} -gt 6 ] && fail "Timeout waiting all nodes to be ready."
+        [ ${tries} -gt 10 ] && fail "Timeout waiting all nodes to be ready."
         local nodes_num_actual=$(exec_on master1 ${KUBECTL_CMD} get node | tail -n +2 | grep -v NotReady | wc -l)
         msg "Expected nodes ${nodes_num_expected}, actual nodes ${nodes_num_actual}."
     done

--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -216,7 +216,7 @@ stage-destroy() {
   cd ${BUILDDIR}
 
   source envs.sh
-
+  sleep 600
   terraform init ../platforms/aws/giantnetes
   terraform destroy -force ../platforms/aws/giantnetes
 

--- a/modules/aws/bastion/bastion-iam.tf
+++ b/modules/aws/bastion/bastion-iam.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role" "bastion" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "${var.iam_region}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -33,18 +33,14 @@ resource "aws_iam_role_policy" "bastion" {
 
   policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
-      ]
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
+        }
+    ]
 }
 EOF
 }

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -1,3 +1,7 @@
+variable "arn_region" {
+  type = "string"
+}
+
 variable "aws_account" {
   type = "string"
 }
@@ -23,6 +27,10 @@ variable "external_ipsec_subnet" {
 }
 
 variable "ignition_bucket_id" {
+  type = "string"
+}
+
+variable "iam_region" {
   type = "string"
 }
 
@@ -60,3 +68,9 @@ variable "vpc_cidr" {
 variable "vpc_id" {
   type = "string"
 }
+
+variable "route53_enabled" {
+  default = true
+}
+
+variable "s3_bucket_tags" {}

--- a/modules/aws/master/master-elb.tf
+++ b/modules/aws/master/master-elb.tf
@@ -61,6 +61,7 @@ resource "aws_security_group" "master_elb" {
 }
 
 resource "aws_route53_record" "master-api" {
+  count   = "${var.route53_enabled ? 1 : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "${var.api_dns}"
   type    = "A"

--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role" "master" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "${var.iam_region}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy" "master" {
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
+        "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
       ]
     }
   ]

--- a/modules/aws/master/master.tf
+++ b/modules/aws/master/master.tf
@@ -1,4 +1,7 @@
 locals {
+  # In China there is no tags for s3 buckets
+  s3_ignition_master_key = "${element(concat(aws_s3_bucket_object.ignition_master_with_tags.*.key, aws_s3_bucket_object.ignition_master_without_tags.*.key), 0)}"
+
   common_tags = "${map(
     "giantswarm.io/installation", "${var.cluster_name}",
     "kubernetes.io/cluster/${var.cluster_name}", "owned"
@@ -125,7 +128,7 @@ resource "aws_security_group" "master" {
 }
 
 resource "aws_route53_record" "master" {
-  count   = "${var.master_count}"
+  count   = "${var.route53_enabled ? var.master_count : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "master${count.index + 1}"
   type    = "CNAME"
@@ -135,6 +138,7 @@ resource "aws_route53_record" "master" {
 
 # NOTE: This works only for the case with one master.
 resource "aws_route53_record" "etcd" {
+  count   = "${var.route53_enabled ? 1 : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "etcd"
   type    = "CNAME"
@@ -144,7 +148,8 @@ resource "aws_route53_record" "etcd" {
 
 # To avoid 16kb user_data limit upload CoreOS ignition config to a s3 bucket.
 # Ignition supports s3 out-of-the-box.
-resource "aws_s3_bucket_object" "ignition_master" {
+resource "aws_s3_bucket_object" "ignition_master_with_tags" {
+  count   = "${var.s3_bucket_tags ? 1 : 0}"
   bucket  = "${var.ignition_bucket_id}"
   key     = "${var.cluster_name}-ignition-master.json"
   content = "${var.user_data}"
@@ -160,9 +165,21 @@ resource "aws_s3_bucket_object" "ignition_master" {
   )}"
 }
 
+# To avoid 16kb user_data limit upload CoreOS ignition config to a s3 bucket.
+# Ignition supports s3 out-of-the-box.
+resource "aws_s3_bucket_object" "ignition_master_without_tags" {
+  count   = "${var.s3_bucket_tags ? 0 : 1}"
+  bucket  = "${var.ignition_bucket_id}"
+  key     = "${var.cluster_name}-ignition-master.json"
+  content = "${var.user_data}"
+  acl     = "private"
+
+  server_side_encryption = "AES256"
+}
+
 data "ignition_config" "s3" {
   replace {
-    source       = "${format("s3://%s/%s", var.ignition_bucket_id, aws_s3_bucket_object.ignition_master.key)}"
+    source       = "${format("s3://%s/%s", var.ignition_bucket_id, local.s3_ignition_master_key)}"
     verification = "sha512-${sha512(var.user_data)}"
   }
 }

--- a/modules/aws/master/variables.tf
+++ b/modules/aws/master/variables.tf
@@ -2,6 +2,10 @@ variable "api_dns" {
   type = "string"
 }
 
+variable "arn_region" {
+  type = "string"
+}
+
 variable "aws_account" {
   type = "string"
 }
@@ -19,6 +23,10 @@ variable "cluster_name" {
 }
 
 variable "ignition_bucket_id" {
+  type = "string"
+}
+
+variable "iam_region" {
   type = "string"
 }
 
@@ -79,3 +87,9 @@ variable "vpc_cidr" {
 variable "vpc_id" {
   type = "string"
 }
+
+variable "route53_enabled" {
+  default = true
+}
+
+variable "s3_bucket_tags" {}

--- a/modules/aws/vault/variables.tf
+++ b/modules/aws/vault/variables.tf
@@ -62,3 +62,7 @@ variable "vpc_cidr" {
 variable "vpc_id" {
   type = "string"
 }
+
+variable "route53_enabled" {
+  default = false
+}

--- a/modules/aws/vault/vault-elb.tf
+++ b/modules/aws/vault/vault-elb.tf
@@ -55,6 +55,7 @@ resource "aws_security_group" "vault_elb" {
 }
 
 resource "aws_route53_record" "vault-elb" {
+  count   = "${var.route53_enabled ? 1 : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "${var.vault_dns}"
   type    = "A"

--- a/modules/aws/vault/vault.tf
+++ b/modules/aws/vault/vault.tf
@@ -84,7 +84,7 @@ resource "aws_security_group" "vault" {
 }
 
 resource "aws_route53_record" "vault" {
-  count   = "${var.vault_count}"
+  count   = "${var.route53_enabled ? var.vault_count : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "vault${count.index + 1}"
   type    = "A"

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -1,3 +1,7 @@
+variable "arn_region" {
+  type = "string"
+}
+
 variable "aws_account" {
   type = "string"
 }

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -164,21 +164,21 @@ resource "aws_vpc_endpoint" "s3" {
       "Principal": "*",
       "Action": "s3:GetObject",
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
+      "Resource": "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
     },
     {
       "Sid": "Etcd-Backup-Rule",
       "Principal": "*",
       "Action": "*",
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::etcd-backups.giantswarm.io/*"
+      "Resource": "arn:${var.arn_region}:s3:::etcd-backups.giantswarm.io/*"
     },
     {
       "Sid": "AWS-Operator-Rule",
       "Principal": "*",
       "Action": "*",
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::*-g8s-*"
+      "Resource": "arn:${var.arn_region}:s3:::*-g8s-*"
     }
   ]
 }

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -1,3 +1,7 @@
+variable "arn_region" {
+  type = "string"
+}
+
 variable "ingress_dns" {
   type = "string"
 }
@@ -19,6 +23,10 @@ variable "cluster_name" {
 }
 
 variable "ignition_bucket_id" {
+  type = "string"
+}
+
+variable "iam_region" {
   type = "string"
 }
 
@@ -78,3 +86,9 @@ variable "vpc_cidr" {
 variable "vpc_id" {
   type = "string"
 }
+
+variable "route53_enabled" {
+  default = true
+}
+
+variable "s3_bucket_tags" {}

--- a/modules/aws/worker-asg/worker-elb.tf
+++ b/modules/aws/worker-asg/worker-elb.tf
@@ -74,6 +74,7 @@ resource "aws_security_group" "worker_elb" {
 }
 
 resource "aws_route53_record" "worker-wildcard" {
+  count   = "${var.route53_enabled ? 1 : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "*"
   type    = "A"
@@ -86,6 +87,7 @@ resource "aws_route53_record" "worker-wildcard" {
 }
 
 resource "aws_route53_record" "worker-ingress" {
+  count   = "${var.route53_enabled ? 1 : 0}"
   zone_id = "${var.dns_zone_id}"
   name    = "${var.ingress_dns}"
   type    = "A"

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role" "worker" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "${var.iam_region}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -69,7 +69,7 @@ resource "aws_iam_role_policy" "worker" {
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
+        "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
       ]
     }
   ]

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -1,3 +1,8 @@
+variable "arn_region" {
+  type    = "string"
+  default = "aws"
+}
+
 variable "cluster_name" {
   type        = "string"
   description = "Need to be unique within the account"
@@ -11,6 +16,17 @@ variable "aws_region" {
 variable "aws_account" {
   type        = "string"
   description = "An AWS account ID."
+}
+
+variable "ami_owner" {
+  type        = "string"
+  default     = "595879546273"
+  description = "ID of the ami owner for CoreOS images."
+}
+
+variable "iam_region" {
+  type    = "string"
+  default = "ec2.amazonaws.com"
 }
 
 variable "nodes_vault_token" {
@@ -28,6 +44,10 @@ variable "logs_expiration_days" {
   type        = "string"
   description = "Number of days access logs will be stored in logging bucket."
   default     = "365"
+}
+
+variable "s3_bucket_tags" {
+  default = true
 }
 
 ### Compute and Storage ###
@@ -111,6 +131,10 @@ variable "root_dns_zone_id" {
   default     = ""
 }
 
+variable "route53_enabled" {
+  default = true
+}
+
 ### Network ###
 
 variable "vpc_cidr" {
@@ -188,4 +212,9 @@ variable "aws_customer_gateway_id" {
 variable "external_ipsec_subnet" {
   description = "CIDR of peering IPSec network."
   default     = "172.18.0.0/30"
+}
+
+### Kubernetes ###
+variable "pod_infra_image" {
+  default = "gcr.io/google_containers/pause-amd64:3.1"
 }


### PR DESCRIPTION
List of changes:

- configurable route53 records
- configurable tags for s3 buckets
- configurable IAM region (as China uses `-cn` prefix)
- configurable pod-infra-container-image