### PR TITLE
Improve ignition container security

### DIFF
--- a/modules/azure/blob/blob.tf
+++ b/modules/azure/blob/blob.tf
@@ -11,7 +11,7 @@ resource "azurerm_storage_container" "ignition" {
   name                  = "ignition"
   resource_group_name   = "${var.resource_group_name}"
   storage_account_name  = "${azurerm_storage_account.storage_acc.name}"
-  container_access_type = "container"
+  container_access_type = "blob"
 }
 
 output "storage_acc" {


### PR DESCRIPTION
This change improves security for ignition container in Azure Blob storage. Unfortunately i did not find elegant solutions to completely prevent anonymous access (and still be able to use from VM).

This change disallows blobs listing in container: `curl 'https://containerxxx.blob.core.windows.net/ignition?restype=container&comp=list'`.

Related to: https://github.com/giantswarm/giantswarm/issues/3041

~I'll also play with [SAS](https://www.terraform.io/docs/providers/azurerm/d/storage_account_sas.html) (temporary access URL). So this PR can be updated.~

