### PR TITLE
Use cheaper resources by default

### DIFF
--- a/modules/azure/bastion-as/bastion.tf
+++ b/modules/azure/bastion-as/bastion.tf
@@ -30,7 +30,7 @@ resource "azurerm_virtual_machine" "bastion" {
 
   storage_os_disk {
     name              = "bastion-${count.index}-os"
-    managed_disk_type = "${var.storage_type}"
+    managed_disk_type = "${var.os_disk_storage_type}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     os_type           = "linux"

--- a/modules/azure/bastion-as/variables.tf
+++ b/modules/azure/bastion-as/variables.tf
@@ -46,9 +46,9 @@ variable "resource_group_name" {
   type = "string"
 }
 
-variable "storage_type" {
+variable "os_disk_storage_type" {
   type        = "string"
-  description = "Storage account type"
+  description = "Storage account type for OS disk."
 }
 
 variable "vm_size" {

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -56,7 +56,7 @@ resource "azurerm_virtual_machine" "master" {
 
   storage_os_disk {
     name              = "master-${count.index}-os"
-    managed_disk_type = "${var.storage_type}"
+    managed_disk_type = "${var.os_disk_storage_type}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     os_type           = "linux"

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -13,7 +13,7 @@ variable "core_ssh_key" {
 
 variable "user_data" {
   type        = "string"
-  description = "Generated user data"
+  description = "Generated user data."
 }
 
 variable "cluster_name" {
@@ -23,7 +23,7 @@ variable "cluster_name" {
 
 variable "location" {
   type        = "string"
-  description = "Location is the Azure Location (East US, West US, etc)"
+  description = "Location is the Azure Location (East US, West US, etc)."
 }
 
 variable "master_count" {
@@ -46,14 +46,19 @@ variable "resource_group_name" {
   type = "string"
 }
 
+variable "os_disk_storage_type" {
+  type        = "string"
+  description = "Storage account type for OS disk."
+}
+
 variable "storage_type" {
   type        = "string"
-  description = "Storage account type"
+  description = "Storage account type."
 }
 
 variable "vm_size" {
   type        = "string"
-  description = "VM Size name"
+  description = "VM Size name."
 }
 
 variable "docker_disk_size" {

--- a/modules/azure/vault/variables.tf
+++ b/modules/azure/vault/variables.tf
@@ -41,6 +41,11 @@ variable "resource_group_name" {
   type = "string"
 }
 
+variable "os_disk_storage_type" {
+  type        = "string"
+  description = "Storage account type for OS disk."
+}
+
 variable "storage_type" {
   type        = "string"
   description = "Storage account type"

--- a/modules/azure/vault/vault.tf
+++ b/modules/azure/vault/vault.tf
@@ -33,7 +33,7 @@ resource "azurerm_virtual_machine" "vault" {
 
   storage_os_disk {
     name              = "vault-os"
-    managed_disk_type = "${var.storage_type}"
+    managed_disk_type = "${var.os_disk_storage_type}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     os_type           = "linux"

--- a/modules/azure/worker-as/variables.tf
+++ b/modules/azure/worker-as/variables.tf
@@ -50,6 +50,11 @@ variable "network_interface_ids" {
   description = "List of NICs to use for Vault VMs"
 }
 
+variable "os_disk_storage_type" {
+  type        = "string"
+  description = "Storage account type for OS disk."
+}
+
 variable "storage_type" {
   type        = "string"
   description = "Storage account type"

--- a/modules/azure/worker-as/worker-as.tf
+++ b/modules/azure/worker-as/worker-as.tf
@@ -51,7 +51,7 @@ resource "azurerm_virtual_machine" "worker" {
 
   storage_os_disk {
     name              = "worker-${count.index}-os"
-    managed_disk_type = "${var.storage_type}"
+    managed_disk_type = "${var.os_disk_storage_type}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
     os_type           = "linux"

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -82,7 +82,7 @@ module "bastion" {
   network_interface_ids       = "${module.vnet.bastion_network_interface_ids}"
   platform_fault_domain_count = "${var.platform_fault_domain_count}"
   resource_group_name         = "${module.resource_group.name}"
-  storage_type                = "${var.bastion_storage_type}"
+  os_disk_storage_type        = "${var.os_disk_storage_type}"
   user_data                   = "${data.ct_config.bastion.rendered}"
   vm_size                     = "${var.bastion_vm_size}"
 }
@@ -112,6 +112,7 @@ module "vault" {
   core_ssh_key            = "${var.core_ssh_key}"
   location                = "${var.azure_location}"
   network_interface_ids   = "${module.vnet.vault_network_interface_ids}"
+  os_disk_storage_type    = "${var.os_disk_storage_type}"
   resource_group_name     = "${module.resource_group.name}"
   storage_type            = "${var.vault_storage_type}"
   user_data               = "${data.ct_config.vault.rendered}"
@@ -171,6 +172,7 @@ module "master" {
   # Only single master supported.
   master_count                = "1"
   resource_group_name         = "${module.resource_group.name}"
+  os_disk_storage_type        = "${var.os_disk_storage_type}"
   platform_fault_domain_count = "${var.platform_fault_domain_count}"
   storage_type                = "${var.master_storage_type}"
 
@@ -230,6 +232,7 @@ module "worker" {
 
   worker_count                = "${var.worker_count}"
   resource_group_name         = "${module.resource_group.name}"
+  os_disk_storage_type        = "${var.os_disk_storage_type}"
   platform_fault_domain_count = "${var.platform_fault_domain_count}"
   storage_type                = "${var.worker_storage_type}"
 

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -49,7 +49,7 @@ variable "nodes_vault_token" {
 variable "worker_count" {
   type        = "string"
   description = "Number of worker nodes to be created."
-  default     = "4"
+  default     = "3"
 }
 
 ### Compute and Storage ###
@@ -59,7 +59,7 @@ variable "bastion_vm_size" {
   default = "Standard_A1"
 }
 
-variable "bastion_storage_type" {
+variable "os_disk_storage_type" {
   type    = "string"
   default = "Standard_LRS"
 }
@@ -76,7 +76,7 @@ variable "vault_storage_type" {
 
 variable "master_vm_size" {
   type    = "string"
-  default = "Standard_DS2_v2"
+  default = "Standard_D2s_v3"
 }
 
 variable "master_storage_type" {
@@ -86,12 +86,12 @@ variable "master_storage_type" {
 
 variable "worker_vm_size" {
   type    = "string"
-  default = "Standard_DS3_v2"
+  default = "Standard_D3s_v3"
 }
 
 variable "worker_storage_type" {
   type    = "string"
-  default = "Premium_LRS"
+  default = "Standard_LRS"
 }
 
 ### Container Linux ###


### PR DESCRIPTION
- use standard disks for OS (3 times cheaper)
- use standard disks for workers 
- deploy 3 workers by defualt (was 4) - tested in `gollum` looks like we have enough resources with 3 workers.
- use `v3` vm sizes (newer and cheaper)