### PR TITLE
Use SAS for ignition object access.

### DIFF
--- a/modules/azure/blob/blob.tf
+++ b/modules/azure/blob/blob.tf
@@ -11,11 +11,15 @@ resource "azurerm_storage_container" "ignition" {
   name                  = "ignition"
   resource_group_name   = "${var.resource_group_name}"
   storage_account_name  = "${azurerm_storage_account.storage_acc.name}"
-  container_access_type = "blob"
+  container_access_type = "private"
 }
 
 output "storage_acc" {
   value = "${azurerm_storage_account.storage_acc.name}"
+}
+
+output "storage_acc_url" {
+  value = "${azurerm_storage_account.storage_acc.primary_connection_string}"
 }
 
 output "storage_container" {

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -98,25 +98,3 @@ resource "azurerm_virtual_machine" "master" {
     GiantSwarmInstallation = "${var.cluster_name}"
   }
 }
-
-resource "local_file" "master_ignition" {
-  content  = "${var.user_data}"
-  filename = "${path.cwd}/generated/master-ignition.yaml"
-}
-
-resource "azurerm_storage_blob" "ignition_blob" {
-  name = "master-ignition-${timestamp()}.yaml"
-
-  resource_group_name    = "${var.resource_group_name}"
-  storage_account_name   = "${var.storage_acc}"
-  storage_container_name = "${var.storage_container}"
-
-  type   = "block"
-  source = "${path.cwd}/generated/master-ignition.yaml"
-}
-
-data "ignition_config" "loader" {
-  replace {
-    source = "${azurerm_storage_blob.ignition_blob.url}"
-  }
-}

--- a/modules/azure/master-as/master-ignition.tf
+++ b/modules/azure/master-as/master-ignition.tf
@@ -1,0 +1,60 @@
+locals {
+  timenow = "${timestamp()}"
+}
+
+# Only necessary, because azurerm_storage_blob requires file as a source.
+resource "local_file" "master_ignition" {
+  content  = "${var.user_data}"
+  filename = "${path.cwd}/generated/master-ignition.yaml"
+}
+
+resource "azurerm_storage_blob" "ignition_blob" {
+  name = "master-ignition-${md5(var.user_data)}.yaml"
+
+  resource_group_name    = "${var.resource_group_name}"
+  storage_account_name   = "${var.storage_acc}"
+  storage_container_name = "${var.storage_container}"
+
+  type   = "block"
+  source = "${path.cwd}/generated/master-ignition.yaml"
+}
+
+# Create temporary credentials to access storage account objects.
+data "azurerm_storage_account_sas" "sas" {
+  connection_string = "${var.storage_acc_url}"
+  https_only        = true
+
+  # Set TTL to 3 months from execution time.
+  start  = "${local.timenow}"
+  expiry = "${timeadd(local.timenow, "2160h")}"
+
+  resource_types {
+    service   = false
+    container = false
+    object    = true
+  }
+
+  services {
+    blob  = true
+    queue = false
+    table = false
+    file  = false
+  }
+
+  permissions {
+    read    = true
+    write   = false
+    delete  = false
+    list    = false
+    add     = false
+    create  = false
+    update  = false
+    process = false
+  }
+}
+
+data "ignition_config" "loader" {
+  replace {
+    source = "${azurerm_storage_blob.ignition_blob.url}${data.azurerm_storage_account_sas.sas.sas}"
+  }
+}

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -78,6 +78,11 @@ variable "storage_acc" {
   description = "Blob storage account name."
 }
 
+variable "storage_acc_url" {
+  type        = "string"
+  description = "Blob storage account URL."
+}
+
 variable "storage_container" {
   type        = "string"
   description = "Blob storage container name."

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -178,6 +178,7 @@ module "master" {
   vm_size               = "${var.master_vm_size}"
 
   storage_acc       = "${module.blob.storage_acc}"
+  storage_acc_url   = "${module.blob.storage_acc_url}"
   storage_container = "${module.blob.storage_container}"
 }
 


### PR DESCRIPTION
This change makes ignition container private and creates temporary SAS credentials for 3 months. SAS is data source and it's renewed everytime terraform run. Also use md5 sum for ignition object name, this allows to prevent master recreation if no changes in ignition data. 

Fixes: https://github.com/giantswarm/giantswarm/issues/3041