### PR TITLE
Allow workers to access vault node exporter

### DIFF
--- a/modules/aws/vault/variables.tf
+++ b/modules/aws/vault/variables.tf
@@ -63,6 +63,10 @@ variable "vpc_id" {
   type = "string"
 }
 
+variable "worker_subnet_ids" {
+  type = "list"
+}
+
 variable "route53_enabled" {
   default = false
 }

--- a/modules/aws/vault/vault.tf
+++ b/modules/aws/vault/vault.tf
@@ -4,7 +4,7 @@ data "aws_availability_zones" "available" {}
 # node-exporter ruler.
 data "aws_subnet" "worker_subnets" {
   count = "${length(var.worker_subnet_ids)}"
-  id = "${var.worker_subnet_ids[count.index]}"
+  id    = "${var.worker_subnet_ids[count.index]}"
 }
 
 resource "aws_instance" "vault" {
@@ -86,9 +86,9 @@ resource "aws_security_group" "vault" {
 
   # Allow node-exporter from worker nodes.
   ingress {
-    from_port = 10300
-    to_port = 10300
-    protocol = "tcp"
+    from_port   = 10300
+    to_port     = 10300
+    protocol    = "tcp"
     cidr_blocks = ["${data.aws_subnet.worker_subnets.*.cidr_block}"]
   }
 

--- a/modules/azure/vnet/nsg-vault.tf
+++ b/modules/azure/vnet/nsg-vault.tf
@@ -38,6 +38,21 @@ resource "azurerm_network_security_rule" "vault_ingress_internal_8200" {
   network_security_group_name = "${azurerm_network_security_group.vault.name}"
 }
 
+resource "azurerm_network_security_rule" "vault_ingress_node-exporter" {
+  name                        = "${var.cluster_name}-vault-node-exporter"
+  description                 = "${var.cluster_name} vault - node-exporter"
+  priority                    = 500
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "TCP"
+  source_port_range           = "*"
+  destination_port_range      = "10300"
+  source_address_prefix       = "${azurerm_subnet.worker_subnet.address_prefix}"
+  destination_address_prefix  = "${var.vnet_cidr}"
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${azurerm_network_security_group.vault.name}"
+}
+
 resource "azurerm_network_security_rule" "vault_egress" {
   name                   = "${var.cluster_name}-vault-out"
   description            = "${var.cluster_name} vault - Outbound"

--- a/modules/azure/vnet/nsg-vault.tf
+++ b/modules/azure/vnet/nsg-vault.tf
@@ -41,7 +41,7 @@ resource "azurerm_network_security_rule" "vault_ingress_internal_8200" {
 resource "azurerm_network_security_rule" "vault_ingress_node-exporter" {
   name                        = "${var.cluster_name}-vault-node-exporter"
   description                 = "${var.cluster_name} vault - node-exporter"
-  priority                    = 500
+  priority                    = 700
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "TCP"

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -135,6 +135,7 @@ module "vault" {
   vault_subnet_ids       = "${module.vpc.vault_subnet_ids}"
   vpc_cidr               = "${var.vpc_cidr}"
   vpc_id                 = "${module.vpc.vpc_id}"
+  worker_subnet_ids      = "${module.vpc.worker_subnet_ids}"
 }
 
 # Generate ignition config for master.


### PR DESCRIPTION
This is needed in order to get vault machine monitored in cloud,
prometheus needs to be allowed to scrape vault machine node-exporter.