### PR TITLE
increase-kubelet-start-timeout

### DIFF
--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -2044,6 +2044,7 @@ systemd:
       After=k8s-setup-network-env.service docker.service calico-certs.service api-certs.service
 
       [Service]
+      TimeoutStartSec=300
       Restart=always
       RestartSec=0
       TimeoutStopSec=10

--- a/ignition/aws/worker.yaml.tmpl
+++ b/ignition/aws/worker.yaml.tmpl
@@ -370,6 +370,7 @@ systemd:
       Requires=k8s-setup-network-env.service docker.service kubelet-certs.service calico-certs.service wait-for-domains.service
 
       [Service]
+      TimeoutStartSec=300
       Restart=always
       RestartSec=0
       TimeoutStopSec=10

--- a/ignition/azure/master.yaml.tmpl
+++ b/ignition/azure/master.yaml.tmpl
@@ -2167,6 +2167,7 @@ systemd:
       Requires=k8s-setup-network-env.service docker.service calico-certs.service api-certs.service
 
       [Service]
+      TimeoutStartSec=300
       Restart=always
       RestartSec=0
       TimeoutStopSec=10

--- a/ignition/azure/worker.yaml.tmpl
+++ b/ignition/azure/worker.yaml.tmpl
@@ -394,6 +394,7 @@ systemd:
       Requires=kubelet-certs.service calico-certs.service
 
       [Service]
+      TimeoutStartSec=300
       Restart=always
       RestartSec=0
       TimeoutStopSec=10


### PR DESCRIPTION
in Atlantis and axolotl the pull of images is quite slow and killing kubelet in the process is slowing the pull even more

We did similar fix also for guest cluster