### PR TITLE
Use static worker count for nginx

### DIFF
--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -681,6 +681,7 @@ storage:
             variables-hash-bucket-size: "128"
             server-name-hash-bucket-size: "1024"
             server-name-hash-max-size: "1024"
+            worker-processes: "4"
     - path: /srv/ingress-controller-sa.yaml
       filesystem: root
       mode: 0644

--- a/ignition/azure/master.yaml.tmpl
+++ b/ignition/azure/master.yaml.tmpl
@@ -667,6 +667,7 @@ storage:
             variables-hash-bucket-size: "128"
             server-name-hash-bucket-size: "1024"
             server-name-hash-max-size: "1024"
+            worker-processes: "4"
     - path: /srv/ingress-controller-sa.yaml
       filesystem: root
       mode: 644


### PR DESCRIPTION
By default controller starts worker number equal to number of cores. Every worker consumes 45MB memory in stand-by, this causes OOM kills (for default limit 700MB) if core number >=16 (Big VMs).

Fixes https://github.com/giantswarm/giantswarm/issues/3536