### PR TITLE
Fix etcd_dns entry propagation

### DIFF
--- a/modules/aws/master/master.tf
+++ b/modules/aws/master/master.tf
@@ -140,7 +140,7 @@ resource "aws_route53_record" "master" {
 resource "aws_route53_record" "etcd" {
   count   = "${var.route53_enabled ? 1 : 0}"
   zone_id = "${var.dns_zone_id}"
-  name    = "etcd"
+  name    = "${var.etcd_dns}"
   type    = "CNAME"
   records = ["${aws_instance.master.0.private_dns}"]
   ttl     = "300"

--- a/modules/aws/master/variables.tf
+++ b/modules/aws/master/variables.tf
@@ -14,6 +14,10 @@ variable "elb_subnet_ids" {
   type = "list"
 }
 
+variable "etcd_dns" {
+  type = "string"
+}
+
 variable "container_linux_ami_id" {
   type = "string"
 }

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -177,6 +177,7 @@ module "master" {
   container_linux_ami_id = "${data.aws_ami.coreos_ami.image_id}"
   dns_zone_id            = "${module.dns.public_dns_zone_id}"
   elb_subnet_ids         = "${module.vpc.elb_subnet_ids}"
+  etcd_dns               = "${var.etcd_dns}"
   ignition_bucket_id     = "${module.s3.ignition_bucket_id}"
   instance_type          = "${var.master_instance["type"]}"
   route53_enabled        = "${var.route53_enabled}"


### PR DESCRIPTION
It was not propagated into master module. Default were working fine, but when we set another value we found that it's broken.