### PR TITLE
Upgrade nginx version to 0.16.2

### DIFF
--- a/ignition/aws/master.yaml.tmpl
+++ b/ignition/aws/master.yaml.tmpl
@@ -733,7 +733,7 @@ storage:
                 serviceAccountName: nginx-ingress-controller
                 containers:
                 - name: nginx-ingress-controller
-                  image: quay.io/giantswarm/nginx-ingress-controller:0.11.0
+                  image: quay.io/giantswarm/nginx-ingress-controller:0.16.2
                   args:
                   - /nginx-ingress-controller
                   - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/ignition/azure/master.yaml.tmpl
+++ b/ignition/azure/master.yaml.tmpl
@@ -719,7 +719,7 @@ storage:
                 serviceAccountName: nginx-ingress-controller
                 containers:
                 - name: nginx-ingress-controller
-                  image: quay.io/giantswarm/nginx-ingress-controller:0.11.0
+                  image: quay.io/giantswarm/nginx-ingress-controller:0.16.2
                   args:
                   - /nginx-ingress-controller
                   - --default-backend-service=$(POD_NAMESPACE)/default-http-backend


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3717

I have tested this version in AWS and Azure host clusters. Even [release page describes](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.16.2) a breaking change it does not affect since we don't apply any psp to IC in host clusters. Adding the security context at container level in our case make the deployment fails (because cannot validate against any PSP)