### PR TITLE
Move ssh users into build

### DIFF
--- a/docs/installation-guide-aws.md
+++ b/docs/installation-guide-aws.md
@@ -58,7 +58,7 @@ NOTE: Reexecute `source envs.sh` in every new console.
 
 ### Configure ssh users
 
-Add bastion users to `igntion/bastion-users.yaml`. All other vms take users configuration from `ignition/users.yaml`, so please modify it too.
+Add bastion users to `build/bastion-users.yaml`. All other vms take users configuration from `build/users.yaml`, so please modify it too.
 
 ### Route53 DNS zone setup
 

--- a/docs/installation-guide-azure.md
+++ b/docs/installation-guide-azure.md
@@ -95,6 +95,10 @@ source envs.sh
 
 NOTE: Reexecute `source envs.sh` everytime if opening new console.
 
+### Configure ssh users
+
+Add bastion users to `build/bastion-users.yaml`. All other vms take users configuration from `build/users.yaml`, so please modify it too.
+
 ## Install
 
 Terraform has one manifest:

--- a/examples/aws/example-build/bastion-users.yaml
+++ b/examples/aws/example-build/bastion-users.yaml
@@ -1,0 +1,10 @@
+passwd:
+  users:
+  # Add your user here.
+  #
+  #- name: user1
+  #  groups:
+  #    - "sudo"
+  #    - "docker"
+  #  ssh_authorized_keys:
+  #    - ssh-rsa XXXXX

--- a/examples/aws/example-build/users.yaml
+++ b/examples/aws/example-build/users.yaml
@@ -1,0 +1,10 @@
+passwd:
+  users:
+  # Add your user here.
+  #
+  #- name: user1
+  #  groups:
+  #    - "sudo"
+  #    - "docker"
+  #  ssh_authorized_keys:
+  #    - ssh-rsa XXXXX

--- a/examples/azure/example-build/bastion-users.yaml
+++ b/examples/azure/example-build/bastion-users.yaml
@@ -1,0 +1,10 @@
+passwd:
+  users:
+  # Add your user here.
+  #
+  #- name: user1
+  #  groups:
+  #    - "sudo"
+  #    - "docker"
+  #  ssh_authorized_keys:
+  #    - ssh-rsa XXXXX

--- a/examples/azure/example-build/users.yaml
+++ b/examples/azure/example-build/users.yaml
@@ -1,0 +1,10 @@
+passwd:
+  users:
+  # Add your user here.
+  #
+  #- name: user1
+  #  groups:
+  #    - "sudo"
+  #    - "docker"
+  #  ssh_authorized_keys:
+  #    - ssh-rsa XXXXX

--- a/ignition/bastion-users.yaml
+++ b/ignition/bastion-users.yaml
@@ -1,10 +1,1 @@
-passwd:
-  users:
-  # Add your user here.
-  #
-  #- name: user1
-  #  groups:
-  #    - "sudo"
-  #    - "docker"
-  #  ssh_authorized_keys:
-  #    - ssh-rsa XXXXX
+../build/bastion-users.yaml

--- a/ignition/users.yaml
+++ b/ignition/users.yaml
@@ -1,10 +1,1 @@
-passwd:
-  users:
-  # Add your user here.
-  #
-  #- name: user1
-  #  groups:
-  #    - "sudo"
-  #    - "docker"
-  #  ssh_authorized_keys:
-  #    - ssh-rsa XXXXX
+../build/users.yaml

--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -115,7 +115,9 @@ stage-prepare-ssh(){
 
     ssh_pub_key=$(cat ${BUILDDIR}/${SSH_USER}.key.pub)
 
-    cat >> ${WORKDIR}/ignition/bastion-users.yaml << EOF
+    cat > ${WORKDIR}/ignition/bastion-users.yaml << EOF
+passwd:
+  users:
   - name: ${SSH_USER}
     groups:
       - "sudo"
@@ -123,7 +125,9 @@ stage-prepare-ssh(){
     ssh_authorized_keys:
       - $(cat ${BUILDDIR}/${SSH_USER}.key.pub)
 EOF
-    cat >> ${WORKDIR}/ignition/users.yaml << EOF
+    cat > ${WORKDIR}/ignition/users.yaml << EOF
+passwd:
+  users:
   - name: ${SSH_USER}
     groups:
       - "sudo"

--- a/misc/e2e-azure.sh
+++ b/misc/e2e-azure.sh
@@ -118,7 +118,9 @@ stage-prepare-ssh(){
     ssh_pub_key=$(cat ${BUILDDIR}/${SSH_USER}.key.pub)
 
     # TODO Add after second line.
-    cat >> ${WORKDIR}/ignition/bastion-users.yaml << EOF
+    cat > ${WORKDIR}/ignition/bastion-users.yaml << EOF
+passwd:
+  users:
   - name: ${SSH_USER}
     groups:
       - "sudo"
@@ -126,7 +128,9 @@ stage-prepare-ssh(){
     ssh_authorized_keys:
       - $(cat ${BUILDDIR}/${SSH_USER}.key.pub)
 EOF
-    cat >> ${WORKDIR}/ignition/users.yaml << EOF
+    cat > ${WORKDIR}/ignition/users.yaml << EOF
+passwd:
+  users:
   - name: ${SSH_USER}
     groups:
       - "sudo"


### PR DESCRIPTION
Refactoring. Move ssh users, which is cluster secific and in general configuration into "build" directory. Use symlinks to build directory.