### PR TITLE
Associate bastions into private routing table

### DIFF
--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -14,6 +14,10 @@ output "worker_subnet_ids" {
   value = ["${aws_subnet.worker_0.id}", "${aws_subnet.worker_1.id}"]
 }
 
+output "private_route_table_ids" {
+  value = ["${aws_route_table.cluster_vpc_private_0.id}", "${aws_route_table.cluster_vpc_private_1.id}"]
+}
+
 output "public_route_table_ids" {
   value = ["${aws_route_table.cluster_vpc_public_0.id}", "${aws_route_table.cluster_vpc_public_1.id}"]
 }

--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -18,10 +18,6 @@ output "private_route_table_ids" {
   value = ["${aws_route_table.cluster_vpc_private_0.id}", "${aws_route_table.cluster_vpc_private_1.id}"]
 }
 
-output "public_route_table_ids" {
-  value = ["${aws_route_table.cluster_vpc_public_0.id}", "${aws_route_table.cluster_vpc_public_1.id}"]
-}
-
 output "vpc_id" {
   value = "${aws_vpc.cluster_vpc.id}"
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -46,3 +46,8 @@ variable "subnet_worker_1" {
 variable "vpc_cidr" {
   type = "string"
 }
+
+variable "with_public_access" {
+  type    = "string"
+  default = ""
+}

--- a/modules/aws/vpc/vpc-subnet-bastion.tf
+++ b/modules/aws/vpc/vpc-subnet-bastion.tf
@@ -26,10 +26,10 @@ resource "aws_subnet" "bastion_1" {
 
 resource "aws_route_table_association" "bastion_0" {
   subnet_id      = "${aws_subnet.bastion_0.id}"
-  route_table_id = "${aws_route_table.cluster_vpc_private_0.id}"
+  route_table_id = "${var.with_public_access == 0 ? aws_route_table.cluster_vpc_private_0.id : aws_route_table.cluster_vpc_public_0.id}"
 }
 
 resource "aws_route_table_association" "bastion_1" {
   subnet_id      = "${aws_subnet.bastion_1.id}"
-  route_table_id = "${aws_route_table.cluster_vpc_private_1.id}"
+  route_table_id = "${var.with_public_access == 0 ? aws_route_table.cluster_vpc_private_1.id : aws_route_table.cluster_vpc_public_1.id}"
 }

--- a/modules/aws/vpc/vpc-subnet-bastion.tf
+++ b/modules/aws/vpc/vpc-subnet-bastion.tf
@@ -26,10 +26,10 @@ resource "aws_subnet" "bastion_1" {
 
 resource "aws_route_table_association" "bastion_0" {
   subnet_id      = "${aws_subnet.bastion_0.id}"
-  route_table_id = "${aws_route_table.cluster_vpc_public_0.id}"
+  route_table_id = "${aws_route_table.cluster_vpc_private_0.id}"
 }
 
 resource "aws_route_table_association" "bastion_1" {
   subnet_id      = "${aws_subnet.bastion_1.id}"
-  route_table_id = "${aws_route_table.cluster_vpc_public_1.id}"
+  route_table_id = "${aws_route_table.cluster_vpc_private_1.id}"
 }

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -2,9 +2,9 @@
 #
 #   * a public route table with the internet gateway as a default route
 #   * a private route table with the private nat gateway as a default route
-#   * bastion and elb subnets are using the public route table
-#   * vault and worker subnets are using the private route table
-#   * the private nat gateway is in the bastion subnet as well (needs to be in a public subnet)
+#   * elb subnets are using the public route table
+#   * bastion, vault and worker subnets are using the private route table
+#   * the private nat gateway is in the elb subnet as well (needs to be in a public subnet)
 
 locals {
   common_tags = "${map(
@@ -44,12 +44,12 @@ resource "aws_internet_gateway" "cluster_vpc" {
 
 resource "aws_nat_gateway" "private_nat_gateway_0" {
   allocation_id = "${aws_eip.private_nat_gateway_0.id}"
-  subnet_id     = "${aws_subnet.bastion_0.id}"
+  subnet_id     = "${aws_subnet.elb_0.id}"
 }
 
 resource "aws_nat_gateway" "private_nat_gateway_1" {
   allocation_id = "${aws_eip.private_nat_gateway_1.id}"
-  subnet_id     = "${aws_subnet.bastion_1.id}"
+  subnet_id     = "${aws_subnet.elb_1.id}"
 }
 
 resource "aws_eip" "private_nat_gateway_0" {

--- a/modules/aws/vpn/vpn.tf
+++ b/modules/aws/vpn/vpn.tf
@@ -63,14 +63,14 @@ resource "aws_vpn_connection_route" "customer_network_1" {
 # Add vpc routes that point to VPN gateways.
 resource "aws_route" "vpc_route_0" {
   count                  = "${var.aws_customer_gateway_id_0 == "" ? 0 : 2}"
-  route_table_id         = "${var.aws_public_route_table_ids[count.index]}"
+  route_table_id         = "${var.aws_private_route_table_ids[count.index]}"
   destination_cidr_block = "${var.aws_external_ipsec_subnet_0}"
   gateway_id             = "${aws_vpn_gateway.vpn_gw.id}"
 }
 
 resource "aws_route" "vpc_route_1" {
   count                  = "${var.aws_customer_gateway_id_1 == "" ? 0 : 2}"
-  route_table_id         = "${var.aws_public_route_table_ids[count.index]}"
+  route_table_id         = "${var.aws_private_route_table_ids[count.index]}"
   destination_cidr_block = "${var.aws_external_ipsec_subnet_1}"
   gateway_id             = "${aws_vpn_gateway.vpn_gw.id}"
 }

--- a/modules/aws/vpn/vpn.tf
+++ b/modules/aws/vpn/vpn.tf
@@ -8,7 +8,7 @@ variable "aws_external_ipsec_subnet_1" {}
 variable "aws_vpn_name" {}
 variable "aws_vpn_vpc_id" {}
 
-variable "aws_public_route_table_ids" {
+variable "aws_private_route_table_ids" {
   type = "list"
 }
 

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -39,17 +39,18 @@ module "dns" {
 module "vpc" {
   source = "../../../modules/aws/vpc"
 
-  arn_region       = "${var.arn_region}"
-  aws_account      = "${var.aws_account}"
-  cluster_name     = "${var.cluster_name}"
-  subnet_bastion_0 = "${var.subnet_bastion_0}"
-  subnet_bastion_1 = "${var.subnet_bastion_1}"
-  subnet_elb_0     = "${var.subnet_elb_0}"
-  subnet_elb_1     = "${var.subnet_elb_1}"
-  subnet_worker_0  = "${var.subnet_worker_0}"
-  subnet_worker_1  = "${var.subnet_worker_1}"
-  subnet_vault_0   = "${var.subnet_vault_0}"
-  vpc_cidr         = "${var.vpc_cidr}"
+  arn_region         = "${var.arn_region}"
+  aws_account        = "${var.aws_account}"
+  cluster_name       = "${var.cluster_name}"
+  subnet_bastion_0   = "${var.subnet_bastion_0}"
+  subnet_bastion_1   = "${var.subnet_bastion_1}"
+  subnet_elb_0       = "${var.subnet_elb_0}"
+  subnet_elb_1       = "${var.subnet_elb_1}"
+  subnet_worker_0    = "${var.subnet_worker_0}"
+  subnet_worker_1    = "${var.subnet_worker_1}"
+  subnet_vault_0     = "${var.subnet_vault_0}"
+  vpc_cidr           = "${var.vpc_cidr}"
+  with_public_access = "${var.aws_customer_gateway_id_0 == "" ? 1 : 0 }"
 }
 
 # Create S3 bucket for ignition configs.

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -247,7 +247,7 @@ module "vpn" {
   aws_cluster_name            = "${var.cluster_name}"
   aws_external_ipsec_subnet_0 = "${var.external_ipsec_subnet_0}"
   aws_external_ipsec_subnet_1 = "${var.external_ipsec_subnet_1}"
-  aws_public_route_table_ids  = "${module.vpc.public_route_table_ids}"
+  aws_private_route_table_ids = "${module.vpc.private_route_table_ids}"
   aws_vpn_name                = "Giant Swarm <-> ${var.cluster_name}"
   aws_vpn_vpc_id              = "${module.vpc.vpc_id}"
 }


### PR DESCRIPTION
As part of enabling logs on bastions, internet access should be turned on there. Also, as bastions don't have now public addresses, they can be associated with private routing table.

  - switch nat gateways to elb subnets (which are the only in public now)
  - move IPSec routes from public routing table into private, which is
  now used by bastions