### PR TITLE
Use e2e-terraform-XXXXXX for CI (w/o dashes for Azure)

### DIFF
--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 WORKDIR=$(pwd)
 BUILDDIR=${WORKDIR}/build
-CLUSTER=e2e-cluster-$(echo ${CIRCLE_SHA1} | cut -c 1-6)
+CLUSTER=e2e-terraform-$(echo ${CIRCLE_SHA1} | cut -c 1-6)
 SSH_USER="e2e"
 KUBECTL_CMD="docker run -i --net=host --rm quay.io/giantswarm/docker-kubectl:8cabd75bacbcdad7ac5d85efc3ca90c2fabf023b"
 WORKER_COUNT=1

--- a/misc/e2e-azure.sh
+++ b/misc/e2e-azure.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 WORKDIR=$(pwd)
 BUILDDIR=${WORKDIR}/build
-CLUSTER=e2e$(echo ${CIRCLE_SHA1} | cut -c 1-4)
+CLUSTER=e2eterraform$(echo ${CIRCLE_SHA1} | cut -c 1-6)
 SSH_USER="e2e"
 KUBECTL_CMD="docker run -i --net=host --rm quay.io/giantswarm/docker-kubectl:8cabd75bacbcdad7ac5d85efc3ca90c2fabf023b"
 WORKER_COUNT=1


### PR DESCRIPTION
We need well-recognized names for e2e tests for ci-cleaner. So use `e2e-terraform-<commit hash 6 chars>` and w/o dashes for Azure, because name restrictions for Azure storage accounts.


From [Azure docs](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-storage-account-name-errors)
> Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.