### PR TITLE
Create proper calico certificates

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -590,6 +590,9 @@ storage:
 
             # If you're using TLS enabled etcd uncomment the following.
             # You must also populate the Secret below with these files.
+
+            # TODO(r7vme): replace with "etcd-ca", "etcd-cert" and "etcd-key"
+            # after all clusters will have them.
             etcd_ca: "/calico-secrets/client-ca.pem"
             etcd_cert: "/calico-secrets/client-crt.pem"
             etcd_key: "/calico-secrets/client-key.pem"
@@ -859,6 +862,7 @@ storage:
                     hostPath:
                       path: /etc/cni/net.d
                   # Mount in the etcd TLS secrets.
+                  # TODO(r7vme): replace with /etc/kubernetes/ssl/calico
                   - name: etcd-certs
                     hostPath:
                       path: /etc/kubernetes/ssl/etcd
@@ -947,6 +951,7 @@ storage:
                         - -r
                 volumes:
                   # Mount in the etcd TLS secrets.
+                  # TODO(r7vme): replace with /etc/kubernetes/ssl/calico
                   - name: etcd-certs
                     hostPath:
                       path: /etc/kubernetes/ssl/etcd
@@ -2659,11 +2664,11 @@ systemd:
           --cluster-id=g8s \
           --common-name={{ .ETCDDomainName }} \
           --ttl=8760h \
-          --crt-file=/etc/kubernetes/ssl/calico/client-crt.pem \
           --ip-sans=127.0.0.1,${DEFAULT_IPV4} \
           --alt-names=localhost \
-          --key-file=/etc/kubernetes/ssl/calico/client-key.pem \
-          --ca-file=/etc/kubernetes/ssl/calico/client-ca.pem); \
+          --ca-file=/etc/kubernetes/ssl/calico/etcd-ca \
+          --crt-file=/etc/kubernetes/ssl/calico/etcd-cert \
+          --key-file=/etc/kubernetes/ssl/calico/etcd-key); \
         done; \
         [ -z "$result" ] && echo "Failed to issue calico certs." && exit 1 || echo "Successfully issued calico certs.";'
       ExecStop=/usr/bin/rm -rf /etc/kubernetes/ssl/calico/

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -401,12 +401,12 @@ systemd:
       EnvironmentFile=/etc/tokens/node
       Type=oneshot
       RemainAfterExit=yes
-      ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl/etcd/
+      ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl/calico/
       ExecStartPre=/bin/bash -c "while ! docker run --rm -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt quay.io/giantswarm/curl -q --silent -o /dev/null https://{{ .VaultDomainName }};  do sleep 2s;echo wait for Vault;done;"
       ExecStart=/usr/bin/docker run \
       --net=host \
       -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
-      -v /etc/kubernetes/ssl/etcd/:/etc/kubernetes/ssl/etcd/ \
+      -v /etc/kubernetes/ssl/calico/:/etc/kubernetes/ssl/calico/ \
       quay.io/giantswarm/certctl:b07d0913d5cb369a6b605394bdd4be4633451be9 \
       issue \
       --vault-addr=https://{{ .VaultDomainName }} \
@@ -414,11 +414,17 @@ systemd:
       --cluster-id=g8s \
       --common-name={{ .ETCDDomainName }} \
       --ttl=8760h \
-      --crt-file=/etc/kubernetes/ssl/etcd/client-crt.pem \
       --ip-sans=127.0.0.1,${DEFAULT_IPV4} \
       --alt-names=localhost \
-      --key-file=/etc/kubernetes/ssl/etcd/client-key.pem \
-      --ca-file=/etc/kubernetes/ssl/etcd/client-ca.pem
+      --ca-file=/etc/kubernetes/ssl/calico/etcd-ca \
+      --crt-file=/etc/kubernetes/ssl/calico/etcd-cert \
+      --key-file=/etc/kubernetes/ssl/calico/etcd-key
+      # TODO(r7vme): Remove steps below after all clusters will have certificates.
+      ExecStartPost=/usr/bin/mkdir -p /etc/kubernetes/ssl/etcd/
+      ExecStartPost=/bin/cp /etc/kubernetes/ssl/calico/etcd-cert /etc/kubernetes/ssl/etcd/client-crt.pem
+      ExecStartPost=/bin/cp /etc/kubernetes/ssl/calico/etcd-ca /etc/kubernetes/ssl/etcd/client-ca.pem
+      ExecStartPost=/bin/cp /etc/kubernetes/ssl/calico/etcd-key /etc/kubernetes/ssl/etcd/client-key.pem
+      ExecStop=/usr/bin/rm -rf /etc/kubernetes/ssl/calico/
       ExecStop=/usr/bin/rm -rf /etc/kubernetes/ssl/etcd/
 
       [Install]


### PR DESCRIPTION
Part of: https://github.com/giantswarm/giantswarm/issues/4173

This is only step 1 into migrating to proper calico certificates. This change makes sure we have `/etc/kubernetes/ssl/calico/` with `etcd-ca` `etcd-cert` `etcd-key`. At the moment we use ones from `/etc/kubernetes/ssl/etcd` and they passed (to CNI) via [environment variables](https://github.com/giantswarm/giantnetes-terraform/blob/master/templates/master.yaml.tmpl#L2852-L2854) in k8s-kubelet.service, which is not right.