### PR TITLE
Use patched k8s v1.11.1 hyperkube image

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1273,7 +1273,7 @@ storage:
                 serviceAccountName: kube-proxy
                 containers:
                 - name: kube-proxy
-                  image: quay.io/giantswarm/hyperkube:v1.11.1
+                  image: quay.io/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
                   command:
                   - /hyperkube
                   - proxy
@@ -2183,7 +2183,7 @@ storage:
             priorityClassName: system-node-critical
             containers:
               - name: k8s-api-server
-                image: quay.io/giantswarm/hyperkube:v1.11.1
+                image: quay.io/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
                 env:
                 - name: HOST_IP
                   valueFrom:
@@ -2274,7 +2274,7 @@ storage:
             priorityClassName: system-node-critical
             containers:
               - name: k8s-controller-manager
-                image: quay.io/giantswarm/hyperkube:v1.11.1
+                image: quay.io/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
                 command:
                 - /hyperkube
                 - controller-manager
@@ -2344,7 +2344,7 @@ storage:
             priorityClassName: system-node-critical
             containers:
               - name: k8s-scheduler
-                image: quay.io/giantswarm/hyperkube:v1.11.1
+                image: quay.io/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
                 command:
                 - /hyperkube
                 - scheduler
@@ -2828,7 +2828,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.11.1"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -477,7 +477,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.11.1"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE


### PR DESCRIPTION
Kubernetes v1.11.1 (and also .2 and .3) apiserver has a memory leak.
There is a fix in apimachinery for it, but upstream release PR is
waiting for testing atm. To mitigate this issue for us in the meanwhile,
we built our own patched version of hyperkube image to enable k8s
v1.11.x clusters.

Towards https://github.com/giantswarm/giantswarm/issues/4187