### PR TITLE
Switch back to iptables in kube-proxy

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1296,7 +1296,7 @@ storage:
                   command:
                   - /hyperkube
                   - proxy
-                  - --proxy-mode ipvs
+                  - --proxy-mode=iptables
                   - --config=/etc/kubernetes/config/proxy-config.yaml
                   - --v=2
                   livenessProbe:


### PR DESCRIPTION
calico-kube-controller is unable to start with kube-proxies in ipvs mode (the reason can be different, but that is just the non-working configuration which breaks stuff). also after calico-kube-controller is up and running, switching back to the ipvs doesn't break stuff. So that's only kube-controller booting issue

Requires more investigation