### PR TITLE
Adds docker log opts to vault machine

### DIFF
--- a/templates/vault.yaml.tmpl
+++ b/templates/vault.yaml.tmpl
@@ -52,6 +52,18 @@ systemd:
           RestartSec=5
 
 storage:
+  files:
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "5m"
+            }
+          }
   filesystems:
     - name: etcd
       mount:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4205

We don't have log options set on the docker daemon for the vault machine, so logs eventually fill the disk.
Equivalent to https://github.com/giantswarm/hive/blob/5487a3fe874cfd682519574c46c98a4a53ed722c/templates/ignition.yaml#L71