### PR TITLE
Enable ipvs in kube-proxy

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1329,6 +1329,9 @@ storage:
                   - mountPath: /etc/kubernetes/ssl
                     name: ssl-certs-kubernetes
                     readOnly: true
+                  - mountPath: /lib/modules
+                    name: lib-modules
+                    readOnly: true
                 volumes:
                 - hostPath:
                     path: /etc/kubernetes/config/
@@ -1339,6 +1342,9 @@ storage:
                 - hostPath:
                     path: /usr/share/ca-certificates
                   name: ssl-certs-host
+                - hostPath:
+                    path: /lib/modules
+                  name: lib-modules
     {{ if eq .Provider "aws" -}}
     - path: /srv/network-policy.json
       filesystem: root

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1304,7 +1304,7 @@ storage:
                   command:
                   - /hyperkube
                   - proxy
-                  - --proxy-mode=iptables
+                  - --proxy-mode=ipvs
                   - --config=/etc/kubernetes/config/proxy-config.yaml
                   - --v=2
                   livenessProbe:


### PR DESCRIPTION
I didn't find issues I had before. Rolled this out to gauss/gollum - also didn't get any issues