### PR TITLE
Remove calico-node service account properly

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -5,12 +5,6 @@ storage:
       mode: 0644
       contents:
         inline: |
-          apiVersion: v1
-          kind: ServiceAccount
-          metadata:
-            name: calico-node
-            namespace: kube-system
-          ---
           {{if eq .Provider "azure" -}}
           #
           # Source: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -351,6 +351,14 @@ storage:
                       path: /etc/cni/net.d
           ---
 
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: calico-node
+            namespace: kube-system
+
+          ---
+
           # Create all the CustomResourceDefinitions needed for
           # Calico policy-only mode.
 


### PR DESCRIPTION
please see my comment here https://github.com/giantswarm/giantnetes-terraform/pull/161

We have separate Calico manifests for aws and azure and each should contain serviceaccount. Why? because this makes easier to maintain calico manifests as they are 99% similar to upstream ones.