### PR TITLE
Wait for Vault VM in e2e tests

### DIFF
--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -293,6 +293,9 @@ main() {
   stage-prepare-ssh
   trap "stage-destroy" EXIT
   stage-terraform-only-vault
+  # Let Vault VM start.
+  # In Azure we don't have this issue, because terraform actually wait when OS is ready.
+  sleep 60
   stage-vault
   stage-terraform
 


### PR DESCRIPTION
Fix issue with unstable e2e tests in AWS.

https://github.com/giantswarm/giantnetes-terraform/pull/147 exposed issue with e2e tests. Seems after change VM starts slower and most of the times this is not enough. Before we immediately were trying to connect to VM, now just add warm up sleep.