### PR TITLE
add-lifecycle-hook-to-asg

### DIFF
--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -59,13 +59,13 @@ resource "aws_cloudformation_stack" "worker_asg" {
     "Type": "AWS::AutoScaling::LifecycleHook",
     "Properties": {
       "AutoScalingGroupName": {
-        "Ref": "!AutoScalingGroup",
+        "Ref": "!AutoScalingGroup"
       },
       "DefaultResult": "CONTINUE",
       "HeartbeatTimeout": 60,
       "LifecycleHookName": "${var.cluster_name}-asg-lifecycle-hook",
-      "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING",
-    },
+      "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING"
+    }
   },
   "Outputs": {
     "AsgName": {

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -55,6 +55,18 @@ resource "aws_cloudformation_stack" "worker_asg" {
       }
     }
   },
+  "LifeCycleHook": {
+    "Type": "AWS::AutoScaling::LifecycleHook",
+    "Properties": {
+      "AutoScalingGroupName": {
+        "Ref": "!AutoScalingGroup",
+      },
+      "DefaultResult": "CONTINUE",
+      "HeartbeatTimeout": 60,
+      "LifecycleHookName": "${var.cluster_name}-asg-lifecycle-hook",
+      "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING",
+    },
+  },
   "Outputs": {
     "AsgName": {
       "Description": "The name of the auto scaling group",

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -53,18 +53,18 @@ resource "aws_cloudformation_stack" "worker_asg" {
           "PauseTime": "PT5M"
         }
       }
-    }
-  },
-  "LifeCycleHook": {
-    "Type": "AWS::AutoScaling::LifecycleHook",
-    "Properties": {
-      "AutoScalingGroupName": {
-        "Ref": "!AutoScalingGroup"
-      },
-      "DefaultResult": "CONTINUE",
-      "HeartbeatTimeout": 60,
-      "LifecycleHookName": "${var.cluster_name}-asg-lifecycle-hook",
-      "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING"
+    },
+    "LifeCycleHook": {
+      "Type": "AWS::AutoScaling::LifecycleHook",
+      "Properties": {
+        "AutoScalingGroupName": {
+          "Ref": "!AutoScalingGroup"
+        },
+        "DefaultResult": "CONTINUE",
+        "HeartbeatTimeout": 60,
+        "LifecycleHookName": "${var.cluster_name}-asg-lifecycle-hook",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING"
+      }
     }
   },
   "Outputs": {

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -58,7 +58,7 @@ resource "aws_cloudformation_stack" "worker_asg" {
       "Type": "AWS::AutoScaling::LifecycleHook",
       "Properties": {
         "AutoScalingGroupName": {
-          "Ref": "!AutoScalingGroup"
+          "Ref": "AutoScalingGroup"
         },
         "DefaultResult": "CONTINUE",
         "HeartbeatTimeout": 60,


### PR DESCRIPTION
add lifecycle hook to control plane ASG for future draining of workers before rolling nodes.

60 sec should be enough for now as we anyway don't have that much pods on nodes and draining is done in few sec, also if something breaks we will wait just extra 1 minutes for rolling


Maybe later we can increase to 120s