### PR TITLE
add-worker-permissions-for-cloudwatch-logs

### DIFF
--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -75,7 +75,8 @@ output "logging_bucket_id" {
 }
 
 resource "aws_cloudwatch_log_group" "control-plane" {
-  name = "${var.cluster_name}-control-plane"
+  name              = "${var.cluster_name}-control-plane"
+  retention_in_days = "90"
 
   tags = "${merge(
     local.common_tags,

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -73,3 +73,14 @@ output "ignition_bucket_id" {
 output "logging_bucket_id" {
   value = "${aws_s3_bucket.logging.id}"
 }
+
+resource "aws_cloudwatch_log_group" "control-plane" {
+  name = "${var.cluster_name}-control-plane"
+
+  tags = "${merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-ignition"
+    )
+  )}"
+}

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -71,6 +71,17 @@ resource "aws_iam_role_policy" "worker" {
       "Resource": [
         "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-ignition/*"
       ]
+    },
+    {
+     "Effect": "Allow",
+     "Action": [
+       "logs:*",
+       "s3:GetObject"
+     ],
+     "Resource": [
+       "arn:aws:logs:${var.arn_region}:*:*",
+       "arn:aws:s3:::*"
+     ]
     }
   ]
 }


### PR DESCRIPTION
add perm for forwarding logs to cloudwatch to worker IAM

I think it makes sense to have this by default

towards https://github.com/giantswarm/giantswarm/issues/4830