### PR TITLE
Use persistent paths for disks

### DIFF
--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -104,6 +104,9 @@ export TF_VAR_root_dns_zone_id=${E2E_AWS_ROUTE53_ZONE}
 export TF_VAR_nodes_vault_token=
 export TF_VAR_aws_customer_gateway_id=
 export TF_VAR_worker_count=${WORKER_COUNT}
+# TODO: Remove this as soon as 1995.0.0 available.
+export TF_VAR_container_linux_version=1995.0.0
+export TF_VAR_container_linux_channel=alpha
 EOF
 }
 

--- a/misc/e2e-azure.sh
+++ b/misc/e2e-azure.sh
@@ -105,6 +105,9 @@ export TF_VAR_root_dns_zone_name="azure.gigantic.io"
 export TF_VAR_nodes_vault_token=
 export TF_VAR_worker_count=${WORKER_COUNT}
 export TF_VAR_delete_data_disks_on_termination="true"
+# TODO: Remove this as soon as 1995.0.0 available.
+export TF_VAR_container_linux_version=1995.0.0
+export TF_VAR_container_linux_channel=alpha
 EOF
 }
 

--- a/modules/aws/master/master.tf
+++ b/modules/aws/master/master.tf
@@ -38,7 +38,6 @@ resource "aws_instance" "master" {
 
 resource "aws_ebs_volume" "master_docker" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  device_name       = "${var.volume_docker}"
   size              = "${var.volume_size_docker}"
   type              = "${var.volume_type}"
 
@@ -51,7 +50,7 @@ resource "aws_ebs_volume" "master_docker" {
 }
 
 resource "aws_volume_attachment" "master_docker" {
-  device_name = "/dev/xvdc"
+  device_name = "${var.volume_docker}"
   volume_id   = "${aws_ebs_volume.master_docker.id}"
   instance_id = "${aws_instance.master.id}"
 

--- a/modules/aws/master/master.tf
+++ b/modules/aws/master/master.tf
@@ -38,6 +38,7 @@ resource "aws_instance" "master" {
 
 resource "aws_ebs_volume" "master_docker" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  device_name       = "${var.volume_docker}"
   size              = "${var.volume_size_docker}"
   type              = "${var.volume_type}"
 

--- a/modules/aws/master/variables.tf
+++ b/modules/aws/master/variables.tf
@@ -80,6 +80,10 @@ variable "volume_size_root" {
   default = 8
 }
 
+variable "volume_docker" {
+  type = "string"
+}
+
 variable "volume_etcd" {
   type = "string"
 }

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -89,13 +89,13 @@ locals {
     "K8SAPIIP"                     = "${var.k8s_api_ip}"
     "K8SDNSIP"                     = "${var.k8s_dns_ip}"
     "K8SServiceCIDR"               = "${var.k8s_service_cidr}"
-    "MasterMountDocker"            = "${var.master_instance["mount_docker"]}"
-    "MasterMountETCD"              = "${var.master_instance["mount_etcd"]}"
+    "MasterMountDocker"            = "${var.master_instance["volume_docker"]}"
+    "MasterMountETCD"              = "${var.master_instance["volume_etcd"]}"
     "PodInfraImage"                = "${var.pod_infra_image}"
     "Provider"                     = "aws"
     "Users"                        = "${file("${path.module}/../../../ignition/users.yaml")}"
     "VaultDomainName"              = "${var.vault_dns}.${var.base_domain}"
-    "WorkerMountDocker"            = "${var.worker_instance["mount_docker"]}"
+    "WorkerMountDocker"            = "${var.worker_instance["volume_docker"]}"
   }
 }
 
@@ -230,6 +230,7 @@ module "master" {
   route53_enabled        = "${var.route53_enabled}"
   user_data              = "${data.ct_config.master.rendered}"
   master_subnet_ids      = "${module.vpc.worker_subnet_ids}"
+  volume_docker          = "${var.master_instance["volume_docker"]}"
   volume_etcd            = "${var.master_instance["volume_etcd"]}"
   vpc_cidr               = "${var.vpc_cidr}"
   vpc_id                 = "${module.vpc.vpc_id}"

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -77,10 +77,9 @@ variable "master_instance" {
   type = "map"
 
   default = {
-    type         = "m5.large"
-    mount_docker = "/dev/nvme1n1"
-    mount_etcd   = "/dev/nvme2n1"
-    volume_etcd  = "/dev/xvdh"
+    type          = "m5.large"
+    volume_docker = "/dev/xvdc"
+    volume_etcd   = "/dev/xvdh"
   }
 }
 
@@ -89,7 +88,6 @@ variable "worker_instance" {
 
   default = {
     type          = "m5.xlarge"
-    mount_docker  = "/dev/nvme1n1"
     volume_docker = "/dev/xvdc"
   }
 }

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -3130,13 +3130,13 @@ storage:
   filesystems:
     - name: docker
       mount:
-        device: {{if eq .Provider "azure" }}/dev/sdc{{else}}{{ .MasterMountDocker }}{{end}}
+        device: {{if eq .Provider "azure" }}/dev/disk/azure/scsi1/lun0{{else}}{{ .MasterMountDocker }}{{end}}
         format: xfs
         wipe_filesystem: false
         label: docker
     - name: etcd
       mount:
-        device: {{if eq .Provider "azure" }}/dev/sdd{{else}}{{ .MasterMountETCD }}{{end}}
+        device: {{if eq .Provider "azure" }}/dev/disk/azure/scsi1/lun1{{else}}{{ .MasterMountETCD }}{{end}}
         format: ext4
         wipe_filesystem: false
         label: var-lib-etcd

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -3132,7 +3132,7 @@ storage:
       mount:
         device: {{if eq .Provider "azure" }}/dev/disk/azure/scsi1/lun0{{else}}{{ .MasterMountDocker }}{{end}}
         format: xfs
-        wipe_filesystem: false
+        wipe_filesystem: true
         label: docker
     - name: etcd
       mount:

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -578,7 +578,7 @@ storage:
   filesystems:
     - name: docker
       mount:
-        device: {{if eq .Provider "azure" }}/dev/sdc{{else}}{{ .WorkerMountDocker }}{{end}}
+        device: {{if eq .Provider "azure" }}/dev/disk/azure/scsi1/lun0{{else}}{{ .WorkerMountDocker }}{{end}}
         format: xfs
         wipe_filesystem: true
         label: docker


### PR DESCRIPTION
Requires CoreOS 1995.0.0.

Tested in gauss and ghost.

depens on: https://github.com/giantswarm/installations/pull/602

We can not use predictable disk names with ignition
as https://github.com/coreos/bugs/issues/2481 was fixed.

![](http://www.quickmeme.com/img/08/086df22ffac0595a67a5de711e08f1283f830d9c907e12c3141569e5eb4838d4.jpg)