### PR TITLE
Update k8s, etcd, calico, coredns

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -16,11 +16,11 @@ storage:
           #   - Made install-cni initContainer.
           #   - Added critical pod priority to calico-node daemonSet and calico-kube-controllers 'priorityClassName: system-cluster-critical'.
           #
-          # Calico Version v3.2.3
-          # https://docs.projectcalico.org/v3.2/releases#v3.2.3
+          # Calico Version v3.4.0
+          # https://docs.projectcalico.org/v3.4/releases#v3.4.0
           # This manifest includes the following component versions:
-          #   calico/node:v3.2.3
-          #   calico/cni:v3.2.3
+          #   calico/node:v3.4.0
+          #   calico/cni:v3.4.0
 
           # This ConfigMap is used to configure a self-hosted Calico installation.
           kind: ConfigMap
@@ -117,6 +117,7 @@ storage:
                   # add-on, ensuring it gets priority scheduling and that its resources are reserved
                   # if it ever gets evicted.
                   scheduler.alpha.kubernetes.io/critical-pod: ''
+                  cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
               spec:
                 nodeSelector:
                   beta.kubernetes.io/os: linux
@@ -130,7 +131,7 @@ storage:
                 serviceAccountName: calico-node
                 priorityClassName: system-cluster-critical
                 containers:
-                - image: {{.DockerRegistry}}/giantswarm/typha:v3.2.3
+                - image: {{.DockerRegistry}}/giantswarm/typha:v3.4.0
                   name: calico-typha
                   ports:
                   - containerPort: 5473
@@ -174,6 +175,23 @@ storage:
                       - check
                       - readiness
                     periodSeconds: 10
+
+          ---
+
+          # This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+
+          apiVersion: policy/v1beta1
+          kind: PodDisruptionBudget
+          metadata:
+            name: calico-typha
+            namespace: kube-system
+            labels:
+              k8s-app: calico-typha
+          spec:
+            maxUnavailable: 1
+            selector:
+              matchLabels:
+                k8s-app: calico-typha
 
           ---
 
@@ -223,12 +241,48 @@ storage:
                 # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
                 # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
                 terminationGracePeriodSeconds: 0
+                initContainers:
+                  # This container installs the Calico CNI binaries
+                  # and CNI network config file on each node.
+                  - name: install-cni
+                    image: {{.DockerRegistry}}/giantswarm/cni:v3.4.0
+                    command: ["/install-cni.sh"]
+                    env:
+                      # Name of the CNI config file to create.
+                      - name: CNI_CONF_NAME
+                        value: "10-calico.conflist"
+                      # The CNI network config to install on each node.
+                      - name: CNI_NETWORK_CONFIG
+                        valueFrom:
+                          configMapKeyRef:
+                            name: calico-config
+                            key: cni_network_config
+                      # Set the hostname based on the k8s node name.
+                      - name: KUBERNETES_NODE_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: spec.nodeName
+                      # Prevents the container from sleeping forever.
+                      - name: SLEEP
+                        value: "false"
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: 100Mi
+                      limits:
+                        cpu: 50m
+                        memory: 100Mi
+                    volumeMounts:
+                      - mountPath: /host/opt/cni/bin
+                        name: cni-bin-dir
+                      - mountPath: /host/etc/cni/net.d
+                        name: cni-net-dir
                 containers:
                   # Runs calico/node container on each Kubernetes node.  This
                   # container programs network policy and routes on each
                   # host.
                   - name: calico-node
-                    image: {{.DockerRegistry}}/giantswarm/node:v3.2.3
+                    image: {{.DockerRegistry}}/giantswarm/node:v3.4.0
                     env:
                       # Use Kubernetes API as the backing datastore.
                       - name: DATASTORE_TYPE
@@ -308,42 +362,6 @@ storage:
                       - mountPath: /var/lib/calico
                         name: var-lib-calico
                         readOnly: false
-                initContainers:
-                  # This container installs the Calico CNI binaries
-                  # and CNI network config file on each node.
-                  - name: install-cni
-                    image: {{.DockerRegistry}}/giantswarm/cni:v3.2.3
-                    command: ["/install-cni.sh"]
-                    env:
-                      # Name of the CNI config file to create.
-                      - name: CNI_CONF_NAME
-                        value: "10-calico.conflist"
-                      # Set the hostname based on the k8s node name.
-                      - name: KUBERNETES_NODE_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: spec.nodeName
-                      # The CNI network config to install on each node.
-                      - name: CNI_NETWORK_CONFIG
-                        valueFrom:
-                          configMapKeyRef:
-                            name: calico-config
-                            key: cni_network_config
-                      # Prevents the container from sleeping forever.
-                      - name: SLEEP
-                        value: "false"
-                    resources:
-                      requests:
-                        cpu: 50m
-                        memory: 100Mi
-                      limits:
-                        cpu: 50m
-                        memory: 100Mi
-                    volumeMounts:
-                      - mountPath: /host/opt/cni/bin
-                        name: cni-bin-dir
-                      - mountPath: /host/etc/cni/net.d
-                        name: cni-net-dir
                 volumes:
                   # Used by calico/node.
                   - name: lib-modules
@@ -498,65 +516,62 @@ storage:
 
           ---
 
-          # Calico Version v3.2.3
-          # https://docs.projectcalico.org/v3.2/releases#v3.2.3
+          # Calico Version v3.4.0
+          # https://docs.projectcalico.org/v3.4/releases#v3.4.0
           kind: ClusterRole
           apiVersion: rbac.authorization.k8s.io/v1
           metadata:
             name: calico-node
           rules:
-            - apiGroups: [""]
-              resources:
-                - namespaces
-                - serviceaccounts
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups: [""]
-              resources:
-                - pods/status
-              verbs:
-                - update
+            # The CNI plugin needs to get pods, nodes, and namespaces.
             - apiGroups: [""]
               resources:
                 - pods
-              verbs:
-                - get
-                - list
-                - watch
-                - patch
-            - apiGroups: [""]
-              resources:
-                - services
+                - nodes
+                - namespaces
               verbs:
                 - get
             - apiGroups: [""]
               resources:
                 - endpoints
+                - services
               verbs:
+                # Used to discover service IPs for advertisement.
+                - watch
+                - list
+                # Used to discover Typhas.
                 - get
             - apiGroups: [""]
               resources:
-                - nodes
+                - nodes/status
               verbs:
-                - get
-                - list
+                # Needed for clearing NodeNetworkUnavailable flag.
+                - patch
+                # Calico stores some configuration information in node annotations.
                 - update
-                - watch
-            - apiGroups: ["extensions"]
-              resources:
-                - networkpolicies
-              verbs:
-                - get
-                - list
-                - watch
+            # Watch for changes to Kubernetes NetworkPolicies.
             - apiGroups: ["networking.k8s.io"]
               resources:
                 - networkpolicies
               verbs:
                 - watch
                 - list
+            # Used by Calico for policy information.
+            - apiGroups: [""]
+              resources:
+                - pods
+                - namespaces
+                - serviceaccounts
+              verbs:
+                - list
+                - watch
+            # The CNI plugin patches pods/status.
+            - apiGroups: [""]
+              resources:
+                - pods/status
+              verbs:
+                - patch
+            # Calico monitors various CRDs for config.
             - apiGroups: ["crd.projectcalico.org"]
               resources:
                 - globalfelixconfigs
@@ -571,11 +586,35 @@ storage:
                 - clusterinformations
                 - hostendpoints
               verbs:
-                - create
                 - get
                 - list
-                - update
                 - watch
+            # Calico must create and update some CRDs on startup.
+            - apiGroups: ["crd.projectcalico.org"]
+              resources:
+                - ippools
+                - felixconfigurations
+                - clusterinformations
+              verbs:
+                - create
+                - update
+            # Calico stores some configuration information on the node.
+            - apiGroups: [""]
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            # These permissions are only requried for upgrade from v2.6, and can
+            # be removed after upgrade or on fresh installations.
+            - apiGroups: ["crd.projectcalico.org"]
+              resources:
+                - bgpconfigurations
+                - bgppeers
+              verbs:
+                - create
+                - update
 
           ---
 
@@ -599,12 +638,12 @@ storage:
           #  - Added resource limits to install-cni.
           #  - Added critical pod priority to calico-node daemonSet and calico-kube-controllers 'priorityClassName: system-cluster-critical'.
           #
-          # Calico Version v3.2.3
-          # https://docs.projectcalico.org/v3.2/releases#v3.2.3
+          # Calico Version v3.4.0
+          # https://docs.projectcalico.org/v3.4/releases#v3.4.0
           # This manifest includes the following component versions:
-          #   calico/node:v3.2.3
-          #   calico/cni:v3.2.3
-          #   calico/kube-controllers:v3.2.3
+          #   calico/node:v3.4.0
+          #   calico/cni:v3.4.0
+          #   calico/kube-controllers:v3.4.0
 
           # This ConfigMap is used to configure a self-hosted Calico installation.
           kind: ConfigMap
@@ -736,7 +775,7 @@ storage:
                   # container programs network policy and routes on each
                   # host.
                   - name: calico-node
-                    image: {{.DockerRegistry}}/giantswarm/node:v3.2.3
+                    image: {{.DockerRegistry}}/giantswarm/node:v3.4.0
                     env:
                       # The location of the Calico etcd cluster.
                       - name: ETCD_ENDPOINTS
@@ -846,10 +885,11 @@ storage:
                         readOnly: false
                       - mountPath: /calico-secrets
                         name: etcd-certs
+                initContainers:
                   # This container installs the Calico CNI binaries
                   # and CNI network config file on each node.
                   - name: install-cni
-                    image: {{.DockerRegistry}}/giantswarm/cni:v3.2.3
+                    image: {{.DockerRegistry}}/giantswarm/cni:v3.4.0
                     command: ["/install-cni.sh"]
                     env:
                       # Name of the CNI config file to create.
@@ -873,6 +913,9 @@ storage:
                           configMapKeyRef:
                             name: calico-config
                             key: veth_mtu
+                      # Prevents the container from sleeping forever.
+                      - name: SLEEP
+                        value: "false"
                     # install-cni also monitors etcd connection,
                     # so use reasonable resource limits.
                     resources:
@@ -961,7 +1004,7 @@ storage:
                 priorityClassName: system-cluster-critical
                 containers:
                   - name: calico-kube-controllers
-                    image: {{.DockerRegistry}}/giantswarm/kube-controllers:v3.2.3
+                    image: {{.DockerRegistry}}/giantswarm/kube-controllers:v3.4.0
                     env:
                       # The location of the Calico etcd cluster.
                       - name: ETCD_ENDPOINTS
@@ -989,7 +1032,7 @@ storage:
                             key: etcd_cert
                       # Choose which controllers to run.
                       - name: ENABLED_CONTROLLERS
-                        value: policy,profile,workloadendpoint,node
+                        value: policy,namespace,serviceaccount,workloadendpoint,node
                     volumeMounts:
                       # Mount in the etcd TLS secrets.
                       - mountPath: /calico-secrets
@@ -1022,8 +1065,8 @@ storage:
 
           ---
 
-          # Calico Version v3.2.3
-          # https://docs.projectcalico.org/v3.2/releases#v3.2.3
+          # Calico Version v3.4.0
+          # https://docs.projectcalico.org/v3.4/releases#v3.4.0
 
           ---
 
@@ -1037,9 +1080,8 @@ storage:
               - extensions
               resources:
                 - pods
-                - namespaces
-                - networkpolicies
                 - nodes
+                - namespaces
                 - serviceaccounts
               verbs:
                 - watch
@@ -1072,12 +1114,28 @@ storage:
           metadata:
             name: calico-node
           rules:
+            # The CNI plugin needs to get pods, nodes, and namespaces.
             - apiGroups: [""]
               resources:
                 - pods
                 - nodes
+                - namespaces
               verbs:
                 - get
+            - apiGroups: [""]
+              resources:
+                - endpoints
+                - services
+              verbs:
+                # Used to discover service IPs for advertisement.
+                - watch
+                - list
+            - apiGroups: [""]
+              resources:
+                - nodes/status
+              verbs:
+                # Needed for clearing NodeNetworkUnavailable flag.
+                - patch
 
           ---
 
@@ -1250,7 +1308,7 @@ storage:
                         topologyKey: kubernetes.io/hostname
                 containers:
                 - name: coredns
-                  image: {{.DockerRegistry}}/giantswarm/coredns:1.1.1
+                  image: {{.DockerRegistry}}/giantswarm/coredns:1.3.0
                   imagePullPolicy: IfNotPresent
                   args: [ "-conf", "/etc/coredns/Corefile" ]
                   volumeMounts:
@@ -1349,7 +1407,7 @@ storage:
                 serviceAccountName: kube-proxy
                 containers:
                 - name: kube-proxy
-                  image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.12.3
+                  image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.13.1
                   command:
                   - /hyperkube
                   - proxy
@@ -2205,7 +2263,7 @@ storage:
           kind: KubeSchedulerConfiguration
           algorithmSource:
             provider: DefaultProvider
-          apiVersion: componentconfig/v1alpha1
+          apiVersion: kubescheduler.config.k8s.io/v1alpha1
           clientConnection:
             kubeconfig: /etc/kubernetes/kubeconfig/scheduler.yaml
           failureDomains: kubernetes.io/hostname,failure-domain.beta.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region
@@ -2302,7 +2360,7 @@ storage:
             priorityClassName: system-node-critical
             containers:
               - name: k8s-api-server
-                image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.12.3
+                image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.13.1
                 env:
                 - name: HOST_IP
                   valueFrom:
@@ -2394,7 +2452,7 @@ storage:
             priorityClassName: system-node-critical
             containers:
               - name: k8s-controller-manager
-                image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.12.3
+                image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.13.1
                 command:
                 - /hyperkube
                 - controller-manager
@@ -2470,7 +2528,7 @@ storage:
             priorityClassName: system-node-critical
             containers:
               - name: k8s-scheduler
-                image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.12.3
+                image: {{.DockerRegistry}}/giantswarm/hyperkube:v1.13.1
                 command:
                 - /hyperkube
                 - scheduler
@@ -2910,7 +2968,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.3.9
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.3.10
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
@@ -2959,7 +3017,7 @@ systemd:
       [Service]
       Type=oneshot
       EnvironmentFile=/etc/environment
-      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.3.9
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.3.10
       Environment=NAME=%p.service
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
@@ -3005,7 +3063,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.DockerRegistry}}/giantswarm/hyperkube:v1.12.3"
+      Environment="IMAGE={{.DockerRegistry}}/giantswarm/hyperkube:v1.13.1"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -521,7 +521,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.DockerRegistry}}/giantswarm/hyperkube:v1.12.3"
+      Environment="IMAGE={{.DockerRegistry}}/giantswarm/hyperkube:v1.13.1"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE


### PR DESCRIPTION
- k8s 1.13.1
- etcd 3.3.10
- calico 3.4.0
- coredns 1.3.0

Tested in `gauss` and `ghost`

Related: https://github.com/giantswarm/giantswarm/issues/4540 https://github.com/giantswarm/giantswarm/issues/4579