### PR TITLE
Mount locally dockershim

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -3076,6 +3076,7 @@ systemd:
       -v /run/calico/:/run/calico/:rw \
       -v /run/docker/:/run/docker/:rw \
       -v /run/docker.sock:/run/docker.sock:rw \
+      -v /run/dockershim:/run/dockershim:rw \
       -v /var/log:/var/log:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
@@ -3096,6 +3097,7 @@ systemd:
       /hyperkube kubelet \
       --config=/etc/kubernetes/config/kubelet.yaml \
       --node-ip=${DEFAULT_IPV4} \
+      --container-runtime-endpoint=/var/run/dockershim/dockershim.sock \
       --containerized \
       --enable-server \
       --logtostderr=true \

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -534,6 +534,7 @@ systemd:
       -v /run/calico/:/run/calico/:rw \
       -v /run/docker/:/run/docker/:rw \
       -v /run/docker.sock:/run/docker.sock:rw \
+      -v /run/dockershim:/run/dockershim:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
       -v /var/lib/calico/:/var/lib/calico/ \
@@ -553,6 +554,7 @@ systemd:
       /hyperkube kubelet \
       --config=/etc/kubernetes/config/kubelet.yaml \
       --node-ip=${DEFAULT_IPV4} \
+      --container-runtime-endpoint=/var/run/dockershim/dockershim.sock \
       --containerized \
       --enable-server \
       --logtostderr=true \


### PR DESCRIPTION
Running kubelet as a container does not expose the `dockershim` socket to the host automatically. By exposing it we can access the common kubernetes CR-I and have enormous benefits in debugging our applications remotely running in the control plane. 

For instance a series of tools out there like https://github.com/solo-io/kubesquash use the common CR interface to operate against the docker API.

Doing that we can also build tools that can operate remotely.