### PR TITLE
Add calicoctl/etcdctl/crictl tools for master

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -2094,15 +2094,6 @@ storage:
             #!/bin/bash
             set -eu
 
-            # download etcdctl
-            ETCD_VERSION=v0.4.5
-            wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
-            tar xvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz
-            mv etcd-${ETCD_VERSION}-linux-amd64/etcdctl /opt/bin/etcdctl
-            chmod +x /opt/bin/etcdctl
-            rm etcd-${ETCD_VERSION}-linux-amd64.tar.gz
-            rm etcd-${ETCD_VERSION}-linux-amd64 -Rf
-
             # download calicoctl
             CALICOCTL_VERSION=v3.5.0
             wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
@@ -3295,7 +3286,7 @@ systemd:
     enabled: true
     contents: |
       [Unit]
-      Description=Calicoctl, etcdctl and crictl tools
+      Description=Calicoctl and crictl tools
       After=network.target
       [Service]
       Type=oneshot

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -2086,6 +2086,58 @@ storage:
 
               echo "Successfully resolved domain $domain"
             done
+    - path: /opt/install-debug-tools
+      filesystem: root
+      mode: 0544
+      contents:
+        inline: |
+            #!/bin/bash
+            set -eu
+
+            # download etcdctl
+            ETCD_VERSION=v0.4.5
+            wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+            tar xvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+            mv etcd-${ETCD_VERSION}-linux-amd64/etcdctl /opt/bin/etcdctl
+            chmod +x /opt/bin/etcdctl
+            rm etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+            rm etcd-${ETCD_VERSION}-linux-amd64 -Rf
+
+            # download calicoctl
+            CALICOCTL_VERSION=v3.5.0
+            wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
+            mv calicoctl-linux-amd64 /opt/bin/calicoctl
+            chmod +x /opt/bin/calicoctl
+
+            # download crictl
+            CRICTL_VERSION=v1.13.0
+            wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+            tar xvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+            mv crictl /opt/bin/crictl
+            chmod +x /opt/bin/crictl
+            rm crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+    - path: /etc/calico/calicoctl.cfg
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          apiVersion: projectcalico.org/v3
+          kind: CalicoAPIConfig
+          metadata:
+          spec:
+            etcdEndpoints: https://{{ .ETCDDomainName }}:2379
+            etcdKeyFile: /etc/kubernetes/ssl/calico/etcd-key
+            etcdCertFile: /etc/kubernetes/ssl/calico/etcd-cert
+            etcdCACertFile: /etc/kubernetes/ssl/calico/etcd-ca
+    - path: /etc/crictl.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          runtime-endpoint: unix:///var/run/dockershim/dockershim.sock
+          image-endpoint: unix:///var/run/dockershim/dockershim.sock
+          timeout: 10
+          debug: false
     - path: /opt/k8s-addons
       filesystem: root
       mode: 0544
@@ -2635,6 +2687,17 @@ storage:
       contents:
         inline: |
           export PS1="WARNING: CONTROL-PLANE MASTER | $PS1"
+    - path: /etc/profile.d/setup-etcdctl.sh
+      filesystem: root
+      mode: 0444
+      contents:
+        inline: |
+          alias etcdctl="ETCDCTL_API=3 \
+                ETCDCTL_ENDPOINTS=https://{{ .ETCDDomainName }}:2379 \
+                ETCDCTL_CACERT=/etc/kubernetes/ssl/etcd/client-ca.pem \
+                ETCDCTL_CERT=/etc/kubernetes/ssl/etcd/client-crt.pem \
+                ETCDCTL_KEY=/etc/kubernetes/ssl/etcd/client-key.pem \
+                etcdctl"
     - path: /opt/bin/confirm
       filesystem: root
       mode: 0555
@@ -3226,6 +3289,17 @@ systemd:
       Type=oneshot
       EnvironmentFile=/etc/network-environment
       ExecStart=/opt/k8s-addons
+      [Install]
+      WantedBy=multi-user.target
+  - name: debug-tools.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Calicoctl, etcdctl and crictl tools
+      After=network.target
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/install-debug-tools
       [Install]
       WantedBy=multi-user.target
 storage:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5216

I don't want to use containers for those debug tools as that adds an additional point of failure in the debug process. But that's just me. Do you think we need containers for those utils?