### PR TITLE
fix-conformance-e2e-test

### DIFF
--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -275,7 +275,7 @@ stage-e2e(){
     # when only one worker. But e2e tests require all pods in kube-system to be Running.
     exec_on master1 ${KUBECTL_CMD} delete deploy nginx-ingress-controller -n kube-system
 
-    exec_on master1 "curl -L ${url} 2>/dev/null | ${KUBECTL_CMD} apply -f -"
+    exec_on master1 ${KUBECTL_CMD} apply -f ${url}
     msg "Started e2e tests..."
 
     sleep 60


### PR DESCRIPTION
to fix error we have on master e2e
```
"docker run" requires at least 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run a command in a new container
bash: line 1: -e: command not found
bash: line 2: -v: command not found
bash: line 3: -v: command not found
```