### PR TITLE
Add giantswarm-critical priority class

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1152,6 +1152,18 @@ storage:
             name: calico-node
             namespace: kube-system
           {{- end }}
+    - path: /srv/priority_classes.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          apiVersion: scheduling.k8s.io/v1alpha1
+          kind: PriorityClass
+          metadata:
+            name: giantswarm-critical
+          value: 1000000000
+          globalDefault: false
+          description: "This priority class is used by giantswarm kubernetes components."
     - path: /srv/default-storage-class.yaml
       filesystem: root
       mode: 0644
@@ -2164,6 +2176,17 @@ storage:
                     echo "failed to apply /srv/$manifest, retrying in 5 sec"
                     sleep 5s
                 done
+            done
+
+            # apply priority classes
+            PRIORITY_CLASSES_FILE="priority_classes.yaml"
+
+            while
+                $KUBECTL apply -f /srv/${PRIORITY_CLASSES_FILE}
+                [ "$?" -ne "0" ]
+            do
+                echo "failed to apply /srv/${PRIORITY_CLASSES_FILE}, retrying in 5 sec"
+                sleep 5s
             done
 
             # create kube-proxy configmap


### PR DESCRIPTION
Align with tenant clusters so we can add priority class `giantswarm-critical` for CP components (we can't reuse system priorityclasses as those works only for `kube-system` ns)