### PR TITLE
fix-azure-subnet-nsg-association

### DIFF
--- a/modules/azure/vnet/vnet-subnets.tf
+++ b/modules/azure/vnet/vnet-subnets.tf
@@ -61,7 +61,7 @@ resource "azurerm_subnet" "worker_subnet" {
 
   # Same for rt association 
   # https://www.terraform.io/docs/providers/azurerm/r/subnet_route_table_association.html
-  route_table_id = "${azurerm_subnet.worker_subnet.id}"
+  route_table_id = "${azurerm_route_table.worker_rt.id}"
 }
 
 resource "azurerm_subnet_route_table_association" "worker" {

--- a/modules/azure/vnet/vnet-subnets.tf
+++ b/modules/azure/vnet/vnet-subnets.tf
@@ -32,6 +32,10 @@ resource "azurerm_subnet" "bastion_subnet" {
 
   # NOTE: bastion_cidr should be unique across clusters, when VPN enabled.
   address_prefix = "${var.bastion_cidr}"
+
+  # We stil need to hold the old deprecated way of defining network security group
+  # https://github.com/hashicorp/terraform/issues/19722
+  network_security_group_id = "${azurerm_network_security_group.bastion.id}"
 }
 
 resource "azurerm_subnet" "vault_subnet" {
@@ -39,6 +43,10 @@ resource "azurerm_subnet" "vault_subnet" {
   resource_group_name  = "${var.resource_group_name}"
   virtual_network_name = "${azurerm_virtual_network.cluster_vnet.name}"
   address_prefix       = "${cidrsubnet(var.vnet_cidr, 8, 1)}"
+
+  # We stil need to hold the old deprecated way of defining network security group
+  # https://github.com/hashicorp/terraform/issues/19722
+  network_security_group_id = "${azurerm_network_security_group.vault.id}"
 }
 
 resource "azurerm_subnet" "worker_subnet" {
@@ -46,6 +54,10 @@ resource "azurerm_subnet" "worker_subnet" {
   resource_group_name  = "${var.resource_group_name}"
   virtual_network_name = "${azurerm_virtual_network.cluster_vnet.name}"
   address_prefix       = "${cidrsubnet(var.vnet_cidr, 8, 2)}"
+
+  # We stil need to hold the old deprecated way of defining network security group
+  # https://github.com/hashicorp/terraform/issues/19722
+  network_security_group_id = "${azurerm_network_security_group.worker.id}"
 }
 
 resource "azurerm_subnet_route_table_association" "worker" {

--- a/modules/azure/vnet/vnet-subnets.tf
+++ b/modules/azure/vnet/vnet-subnets.tf
@@ -58,6 +58,10 @@ resource "azurerm_subnet" "worker_subnet" {
   # We stil need to hold the old deprecated way of defining network security group
   # https://github.com/hashicorp/terraform/issues/19722
   network_security_group_id = "${azurerm_network_security_group.worker.id}"
+
+  # Same for rt association 
+  # https://www.terraform.io/docs/providers/azurerm/r/subnet_route_table_association.html
+  route_table_id = "${azurerm_subnet.worker_subnet.id}"
 }
 
 resource "azurerm_subnet_route_table_association" "worker" {


### PR DESCRIPTION
looks like we still need to use the deprecated method of network security group association and route table association   until azureRM reaches 2.0

at least we are prepared and  afterward, we just remove the 3 lines
see this https://github.com/hashicorp/terraform/issues/19722