### PR TITLE
Fix worker iam-role access to logs

### DIFF
--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role_policy" "worker" {
        "s3:GetObject"
      ],
      "Resource": [
-       "arn:${var.arn_region}:logs:${var.iam_region}:*:*",
+       "arn:${var.arn_region}:logs:${var.aws_region}:*:*",
        "arn:${var.arn_region}:s3:::*"
      ]
     }

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role_policy" "worker" {
        "s3:GetObject"
      ],
      "Resource": [
-       "arn:${var.arn_region}:logs:${var.arn_region}:*:*",
+       "arn:${var.arn_region}:logs:${var.iam_region}:*:*",
        "arn:${var.arn_region}:s3:::*"
      ]
     }


### PR DESCRIPTION
Current setup never gives access for fluentd to Cloudwatch with error

```
fluentd-686d7dfcf9-xbvkx fluentd 2019-03-26 13:28:58 +0000 [warn]: #0 failed to flush the buffer. retry_time=10 next_retry_seconds=2019-03-26 13:28:58 +0000 chunk="584ff0ccf66a339bbc2cf6b768090049" error_class=Aws::CloudWatchLogs::Errors::AccessDeniedException error="User: arn:aws:sts::452825986764:assumed-role/viking-worker/i-0e5cb8fbb70ee8d6b is not authorized to perform: logs:DescribeLogGroups on resource: arn:aws:logs:eu-central-1:452825986764:log-group::log-stream:"
```

This is because of wrong iam role access.