### PR TITLE
Add timeout flags for etcd defrag

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -3188,7 +3188,10 @@ systemd:
         --cacert /etc/etcd/server-ca.pem \
         --cert /etc/etcd/server-crt.pem \
         --key /etc/etcd/server-key.pem \
-        defrag
+        defrag  \
+          --command-timeout=60s \
+          --dial-timeout=60s \
+          --keepalive-timeout=25s
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
Without this, we have defrag service failing (we have those flags in tenant clusters for last few releases)