### PR TITLE
Disable kms auto-unseal aws

### DIFF
--- a/modules/aws/vault/vault-iam.tf
+++ b/modules/aws/vault/vault-iam.tf
@@ -1,7 +1,6 @@
 resource "aws_iam_role" "vault" {
-  count = "${var.vault_auto_unseal ? 1 : 0}"
-  name  = "${var.cluster_name}-vault"
-  path  = "/"
+  name = "${var.cluster_name}-vault"
+  path = "/"
 
   lifecycle {
     create_before_destroy = true
@@ -48,9 +47,8 @@ resource "aws_iam_role_policy" "vault-kms-unseal" {
 }
 
 resource "aws_iam_role_policy" "vault-s3-ignition" {
-  count = "${var.vault_auto_unseal ? 1 : 0}"
-  name  = "${var.cluster_name}-vault-s3-ignition"
-  role  = "${aws_iam_role.vault.id}"
+  name = "${var.cluster_name}-vault-s3-ignition"
+  role = "${aws_iam_role.vault.id}"
 
   policy = <<EOF
 {

--- a/modules/aws/vault/vault-iam.tf
+++ b/modules/aws/vault/vault-iam.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "vault" {
-  name = "${var.cluster_name}-vault"
-  path = "/"
+  count = "${var.vault_auto_unseal ? 1 : 0}"
+  name  = "${var.cluster_name}-vault"
+  path  = "/"
 
   lifecycle {
     create_before_destroy = true
@@ -24,6 +25,8 @@ EOF
 }
 
 data "aws_iam_policy_document" "vault-kms-unseal" {
+  count = "${var.vault_auto_unseal ? 1 : 0}"
+
   statement {
     sid       = "VaultKMSUnseal"
     effect    = "Allow"
@@ -38,14 +41,16 @@ data "aws_iam_policy_document" "vault-kms-unseal" {
 }
 
 resource "aws_iam_role_policy" "vault-kms-unseal" {
+  count  = "${var.vault_auto_unseal ? 1 : 0}"
   name   = "${var.cluster_name}-vault-kms-unseal"
   role   = "${aws_iam_role.vault.id}"
   policy = "${data.aws_iam_policy_document.vault-kms-unseal.json}"
 }
 
 resource "aws_iam_role_policy" "vault-s3-ignition" {
-  name = "${var.cluster_name}-vault-s3-ignition"
-  role = "${aws_iam_role.vault.id}"
+  count = "${var.vault_auto_unseal ? 1 : 0}"
+  name  = "${var.cluster_name}-vault-s3-ignition"
+  role  = "${aws_iam_role.vault.id}"
 
   policy = <<EOF
 {
@@ -66,8 +71,9 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "vault" {
-  name = "${var.cluster_name}-vault"
-  role = "${aws_iam_role.vault.name}"
+  count = "${var.vault_auto_unseal ? 1 : 0}"
+  name  = "${var.cluster_name}-vault"
+  role  = "${aws_iam_role.vault.name}"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/aws/vault/vault-iam.tf
+++ b/modules/aws/vault/vault-iam.tf
@@ -69,9 +69,8 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "vault" {
-  count = "${var.vault_auto_unseal ? 1 : 0}"
-  name  = "${var.cluster_name}-vault"
-  role  = "${aws_iam_role.vault.name}"
+  name = "${var.cluster_name}-vault"
+  role = "${aws_iam_role.vault.name}"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/aws/vault/vault-kms-endpoint.tf
+++ b/modules/aws/vault/vault-kms-endpoint.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc_endpoint" "kms" {
-  count             = "${var.vault_count}"
+  count             = "${var.vault_auto_unseal ? 1 : 0}"
   vpc_id            = "${var.vpc_id}"
   service_name      = "com.amazonaws.${var.aws_region}.kms"
   vpc_endpoint_type = "Interface"

--- a/modules/aws/vault/vault-kms.tf
+++ b/modules/aws/vault/vault-kms.tf
@@ -1,4 +1,5 @@
 resource "aws_kms_key" "vault-unseal-key" {
+  count                   = "${var.vault_auto_unseal ? 1 : 0}"
   description             = "${var.cluster_name} vault unseal key"
   deletion_window_in_days = 10
 
@@ -9,6 +10,7 @@ resource "aws_kms_key" "vault-unseal-key" {
 }
 
 resource "aws_kms_alias" "vault-unseal-key" {
+  count         = "${var.vault_auto_unseal ? 1 : 0}"
   name          = "alias/${var.cluster_name}-vault-unseal-key"
   target_key_id = "${aws_kms_key.vault-unseal-key.key_id}"
 }

--- a/modules/aws/vault/vault.tf
+++ b/modules/aws/vault/vault.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "vault" {
   instance_type = "${var.instance_type}"
 
   associate_public_ip_address = false
-  iam_instance_profile        = "${aws_iam_instance_profile.vault.id}"
+  iam_instance_profile        = "${var.vault_auto_unseal ? aws_iam_instance_profile.vault.id : ""}"
   source_dest_check           = false
   subnet_id                   = "${var.vault_subnet_ids[count.index]}"
   vpc_security_group_ids      = ["${aws_security_group.vault.id}"]

--- a/modules/aws/vault/vault.tf
+++ b/modules/aws/vault/vault.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "vault" {
   instance_type = "${var.instance_type}"
 
   associate_public_ip_address = false
-  iam_instance_profile        = "${var.vault_auto_unseal ? aws_iam_instance_profile.vault.id : ""}"
+  iam_instance_profile        = "${aws_iam_instance_profile.vault.id}"
   source_dest_check           = false
   subnet_id                   = "${var.vault_subnet_ids[count.index]}"
   vpc_security_group_ids      = ["${aws_security_group.vault.id}"]


### PR DESCRIPTION
During the provision of `giraffe` kms endpoint and other stuff were created but in AWS China is not possible so we have to flag the creation

Tested in giraffe