### PR TITLE
CP components ssh config and hardening

### DIFF
--- a/templates/bastion.yaml.tmpl
+++ b/templates/bastion.yaml.tmpl
@@ -23,7 +23,9 @@ systemd:
         Description=Apply os hardening
         [Service]
         Type=oneshot
-        ExecStart=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+        ExecStartPre=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+        ExecStartPre=/bin/bash -c "until [ -f '/etc/sysctl.d/hardening.conf' ]; do echo Waiting for sysctl file; sleep 1s;done;"
+        ExecStart=/usr/sbin/sysctl -p /etc/sysctl.d/hardening.conf
         [Install]
         WantedBy=multi-user.target
     {{if eq .Provider "aws" -}}
@@ -55,6 +57,32 @@ systemd:
     {{end }}
 storage:
   files:
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0600
+      contents:
+        inline: |
+          # Use most defaults for sshd configuration.
+          Subsystem sftp internal-sftp
+          ClientAliveInterval 180
+          UseDNS no
+          UsePAM yes
+          PrintLastLog no # handled by PAM
+          PrintMotd no # handled by PAM
+          # Non defaults (#100)
+          ClientAliveCountMax 2
+          PasswordAuthentication no
+          MaxAuthTries 5
+          LoginGraceTime 60
+    - path: /etc/sysctl.d/hardening.conf
+      filesystem: root
+      mode: 0600
+      contents: 
+        inline: |
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.all.arp_ignore = 1
+          net.ipv4.conf.all.arp_announce = 2
+
     {{if eq .Provider "aws" -}}
     - path: /etc/journald-cloudwatch.conf
       filesystem: root

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -2741,6 +2741,8 @@ storage:
           ClientAliveCountMax 2
           PasswordAuthentication no
           TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
+          MaxAuthTries 5
+          LoginGraceTime 60
     - path: /opt/get-ca.sh
       filesystem: root
       mode: 0770
@@ -2804,6 +2806,9 @@ storage:
           net.ipv4.tcp_timestamps = 0
           net.ipv6.conf.all.accept_redirects = 0
           net.ipv6.conf.default.accept_redirects = 0
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.all.arp_ignore = 1
+          net.ipv4.conf.all.arp_announce = 2
 
     - path: /etc/audit/rules.d/10-docker.rules
       filesystem: root

--- a/templates/vault.yaml.tmpl
+++ b/templates/vault.yaml.tmpl
@@ -61,6 +61,18 @@ systemd:
           [Service]
           Restart=always
           RestartSec=5
+    - name: os-hardening.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Apply os hardening
+        [Service]
+        Type=oneshot
+        ExecStartPre=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+        ExecStartPre=/bin/bash -c "until [ -f '/etc/sysctl.d/hardening.conf' ]; do echo Waiting for sysctl file; sleep 1s;done;"
+        ExecStart=/usr/sbin/sysctl -p /etc/sysctl.d/hardening.conf
+        [Install]
+        WantedBy=multi-user.target
 
 storage:
   filesystems:
@@ -77,6 +89,35 @@ storage:
         wipe_filesystem: false
         label: var-log
   files:
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0600
+      contents:
+        inline: |
+          # Use most defaults for sshd configuration.
+          Subsystem sftp internal-sftp
+          ClientAliveInterval 180
+          UseDNS no
+          UsePAM yes
+          PrintLastLog no # handled by PAM
+          PrintMotd no # handled by PAM
+          # Non defaults (#100)
+          ClientAliveCountMax 2
+          PasswordAuthentication no
+          TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
+          MaxAuthTries 5
+          LoginGraceTime 60
+          AllowTcpForwarding no
+          AllowAgentForwarding no
+    - path: /etc/sysctl.d/hardening.conf
+      filesystem: root
+      mode: 0600
+      contents: 
+        inline: |
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.all.arp_ignore = 1
+          net.ipv4.conf.all.arp_announce = 2
+
     {{ if .VaultAutoUnseal -}}
     - path: /etc/vault/vault-auto-unseal.hcl
       filesystem: root

--- a/templates/vpn.yaml.tmpl
+++ b/templates/vpn.yaml.tmpl
@@ -19,7 +19,9 @@ systemd:
         Description=Apply os hardening
         [Service]
         Type=oneshot
-        ExecStart=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+        ExecStartPre=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+        ExecStartPre=/bin/bash -c "until [ -f '/etc/sysctl.d/hardening.conf' ]; do echo Waiting for sysctl file; sleep 1s;done;"
+        ExecStart=/usr/sbin/sysctl -p /etc/sysctl.d/hardening.conf
         [Install]
         WantedBy=multi-user.target
     - name: template-ipsec-config.service
@@ -79,6 +81,35 @@ systemd:
         WantedBy=multi-user.target
 storage:
   files:
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0600
+      contents:
+        inline: |
+          # Use most defaults for sshd configuration.
+          Subsystem sftp internal-sftp
+          ClientAliveInterval 180
+          UseDNS no
+          UsePAM yes
+          PrintLastLog no # handled by PAM
+          PrintMotd no # handled by PAM
+          # Non defaults (#100)
+          ClientAliveCountMax 2
+          PasswordAuthentication no
+          MaxAuthTries 5
+          LoginGraceTime 60
+          AllowTcpForwarding no
+          AllowAgentForwarding no
+
+    - path: /etc/sysctl.d/hardening.conf
+      filesystem: root
+      mode: 0600
+      contents: 
+        inline: |
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.all.arp_ignore = 1
+          net.ipv4.conf.all.arp_announce = 2
+
     - path: /opt/bin/template-ipsec-config
       filesystem: root
       mode: 0700

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -193,6 +193,8 @@ storage:
           TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
           MaxAuthTries 5
           LoginGraceTime 60
+          AllowTcpForwarding no
+          AllowAgentForwarding no
 
     - path: /opt/get-ca.sh
       filesystem: root

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -191,6 +191,8 @@ storage:
           ClientAliveCountMax 2
           PasswordAuthentication no
           TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
+          MaxAuthTries 5
+          LoginGraceTime 60
 
     - path: /opt/get-ca.sh
       filesystem: root
@@ -242,6 +244,9 @@ storage:
           net.ipv4.tcp_timestamps = 0
           net.ipv6.conf.all.accept_redirects = 0
           net.ipv6.conf.default.accept_redirects = 0
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.all.arp_ignore = 1
+          net.ipv4.conf.all.arp_announce = 2
 
     - path: /etc/audit/rules.d/10-docker.rules
       filesystem: root


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6070

I've disabled TCP Forwarding and Agent Forward only in the case of the workers because we don't jump on TC via workers

This one 

> protection for buffer overflows needs to be active, which seems to be standard. In Linux the file /etc/sysctl.conf should have kernel.exec-shield = 1 and kernel.randomize_va_space = 2. The NX-Bit styrting with Linux-Kernel 2.6.8 needs to be enabled by default

is already satisfied in the OS as below showed

```
WARNING: CONTROL-PLANE NODE | giantswarm@master-172-16-227-131 ~ $ grep -Fw nx /proc/cpuinfo
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf pni pclmulqdq vmx ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt aes xsave avx hypervisor lahf_lm epb pti tpr_shadow vnmi ept vpid dtherm ida arat pln pts
WARNING: CONTROL-PLANE NODE | giantswarm@master-172-16-227-131 ~ $ dmesg | grep -Fw NX
[    0.000000] NX (Execute Disable) protection: active
```


Note that this is done only for master and worker in CP. do we need to apply this for VPN, Vault and bastion instances?