### PR TITLE
ct provider URL needs updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terraform manifests for installing Giant Swarm's control plane.
 install terraform plugin: `terraform-provider-ct`
 ```
 mkdir -p ${HOME}/.terraform.d/plugins/linux_amd64
-go get -u github.com/coreos/terraform-provider-ct
+go get -u github.com/poseidon/terraform-provider-ct
 ln -sf ${GOPATH}/bin/terraform-provider-ct ${HOME}/.terraform.d/plugins/linux_amd64/terraform-provider-ct
 ```
 install terraform plugin: `terraform-provider-gotemplate`


### PR DESCRIPTION
It seems the repo for `terraform-provider-ct` has [been renamed ](https://github.com/poseidon/terraform-provider-ct/commit/77d8a2d41066aa40497f1fdf8a1e37a3f71311ac) which breaks pulling down the module (at least it did for me).