### PR TITLE
Add  variable type to aws vault subnet

### DIFF
--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -221,6 +221,7 @@ variable "subnets_elb" {
 
 variable "subnets_vault" {
   description = "CIDR for Vault network."
+  type        = "list"
   default     = ["10.0.3.0/25"]
 }
 


### PR DESCRIPTION
Add  variable type to AWS vault subnet

to fix
```
module.master.aws_volume_attachment.master_etcd[2]: Refreshing state... [id=vai-3116947638]

Error: Invalid value for module argument

  on main.tf line 58, in module "vpc":
  58:   subnets_vault      = "${var.subnets_vault}"

The given value is not suitable for child module variable "subnets_vault"
defined at ../../../modules/aws/vpc/variables.tf:26,1-25: list of any single
type required.

Releasing state lock. This may take a few moments...
```