### PR TITLE
Add k8s subdomain for external k8s api access

### DIFF
--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -96,6 +96,7 @@ locals {
     "ExternalVpnVultrPassword"     = "${var.external_ipsec_password}"
     "ExternalVpnVultrSubnet"       = "${var.external_ipsec_subnet_1}"
     "ExternalVpnVultrSourceIp"     = "${cidrhost("${var.external_ipsec_subnet_1}",1)}"
+    "ExternalAPIDomainName"        = "${var.external_api_dns}.${var.api_dns}.${var.base_domain}"
     "G8SVaultToken"                = "${var.nodes_vault_token}"
     "ImagePullProgressDeadline"    = "${var.image_pull_progress_deadline}"
     "K8SAPIIP"                     = "${var.k8s_api_ip}"

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -133,6 +133,12 @@ variable "api_dns" {
   default     = "g8s"
 }
 
+variable "api_external_dns" {
+  type        = "string"
+  description = "External FQDN for api (i.e. k8s)."
+  default     = "k8s"
+}
+
 variable "etcd_dns" {
   type        = "string"
   description = "FQDN for etcd (i.e. etcd). '__MASTER_ID__' wil be replaced with id of master"

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -82,6 +82,7 @@ locals {
     "ETCDDomainName"           = "${var.etcd_dns}.${var.base_domain}"
     "ETCDInitialClusterMulti"  = "etcd1=https://etcd1.${var.base_domain}:2380,etcd2=https://etcd2.${var.base_domain}:2380,etcd3=https://etcd3.${var.base_domain}:2380"
     "ETCDInitialClusterSingle" = "etcd1=https://etcd1.${var.base_domain}:2380"
+    "ExternalAPIDomainName"    = "${var.external_api_dns}.${var.api_dns}.${var.base_domain}"
     "G8SVaultToken"            = "${var.nodes_vault_token}"
     "K8SAPIIP"                 = "${var.k8s_api_ip}"
     "K8SAuditWebhookPort"      = "${var.k8s_audit_webhook_port}"

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -141,6 +141,12 @@ variable "api_dns" {
   default     = "g8s"
 }
 
+variable "api_external_dns" {
+  type        = "string"
+  description = "External FQDN for api (i.e. k8s)."
+  default     = "k8s"
+}
+
 variable "etcd_dns" {
   type        = "string"
   description = "FQDN for etcd (i.e. etcd). '__MASTER_ID__' wil be replaced with id of master"

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -3401,7 +3401,7 @@ systemd:
       --ttl=8760h \
       --crt-file=/etc/kubernetes/ssl/apiserver-crt.pem \
       --ip-sans=127.0.0.1,${DEFAULT_IPV4},{{ .K8SAPIIP }} \
-      --alt-names=localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.local \
+      --alt-names={{ .ExternalAPIDomainName }},localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.local \
       --allowed-domains={{.BaseDomain}},localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.local \
       --allow-bare-domains=true \
       --organizations=system:masters \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6467

To make it possible providing customers read-only access to control-plane API, we need expose somehow API access on network level. Currently it is behind private balancer, which is available only via VPN. 

This can be solved by adding ingress resource with passthrough. Used domain in ingress must be allowed in alt_names of the api certificates. So this PR allows it.

Not sure about naming, maybe it should be something explicit like `external-k8s-api.g8s.<base-domain>`. Thoughts?


