### PR TITLE
Extend readonly role

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1739,9 +1739,90 @@ storage:
           rules:
           - apiGroups:
             - ""
+            - apiregistration.k8s.io
+            - batch
+            - certmanager.k8s.io
+            - cluster.k8s.io
+            - clusterissuers
+            - coordination.k8s.io
+            - extensions
+            - issuers
+            - networking.k8s.io
+            - rbac.authorization
+            - scheduling.k8s.io
+            - storage.k8s.io
             resources:
+            - apiservices
+            - certificate
+            - componentstatus
+            - clusterroles
+            - clusterrolebindings
+            - clusters
+            - configmaps
+            - cronjobs
+            - daemonsets
+            - deployments
+            - endpoints
+            - ingresses
+            - leases
+            - machinedeployments
+            - namespaces
+            - networkpolicies
+            - nodeconfigs
             - nodes
+            - pods
+            - podsecuritypolicies
+            - priorityclasses
+            - replicasets
+            - roles
+            - rolebindings
+            - serviceaccounts
+            - services
+            - storageclass
             verbs:
+            - get
+            - list
+          - apiGroups:
+            - ""
+            resources:
+            - secrets
+            verbs:
+            - list
+          - apiGroups:
+            - application.giantswarm.io
+            - cluster.giantswarm.io
+            - core.giantswarm.io
+            - provider.giantswarm.io
+            resources:
+            - apps
+            - appcatalogs
+            - awsclusterconfigs
+            - awsconfigs
+            - awses
+            - azureclusterconfigs
+            - certconfigs
+            - certificates
+            - chartconfigs
+            - charts
+            - clusterissuers
+            - componentstatus
+            - drainerconfigs
+            - flannelconfigs
+            - ingressconfigs
+            - issuers
+            - kvmclusterconfigs
+            - kvmconfigs
+            - nodeconfigs
+            - releasecycles
+            - releases
+            - storageconfigs
+            - storagepoolclaims
+            - storagepools
+            - volumepolicies
+            - volumesnapshotdatas
+            - volumesnapshots
+            verbs:
+            - get
             - list
           ---
           ## CoreDNS

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1758,7 +1758,6 @@ storage:
             - clusterroles
             - clusterrolebindings
             - clusters
-            - configmaps
             - cronjobs
             - daemonsets
             - deployments
@@ -1782,6 +1781,62 @@ storage:
             verbs:
             - get
             - list
+          - apiGroups:
+            - ""
+            resources:
+            - configmaps
+            verbs:
+            - list
+          - apiGroups:
+            - ""
+            resources:
+            - configmaps
+            resourceNames:
+            - api-configmap
+            - app-operator
+            - aws-operator-configmap
+            - azure-operator-configmap
+            - bridge-operator-configmap
+            - cert-operator-configmap
+            - chart-operator
+            - cluster-operator-configmap
+            - cluster-service-configmap
+            - credentiald-configmap
+            - desmotes-configmap
+            - flannel-operator-configmap
+            - giantswarm-incubator
+            - giantswarm-incubator-test
+            - happa-configmap
+            - ingress-operator-configmap
+            - kubernetesd-configmap
+            - kvm-operator-configmap
+            - node-operator-configmap
+            - passage-configmap
+            - passage-nginx-config
+            - pv-cleaner-operator-configmap
+            - release-operator-configmap
+            - calico-config
+            - coredns
+            - ingress-controller-leader-nginx
+            - ingress-nginx
+            - ingress-nginx-tcp-services
+            - kube-proxy
+            - alertmanager
+            - alertmanager-templates
+            - elasticsearch
+            - fluentbit-config
+            - fluentd-config
+            - grafana-dashboards-json
+            - grafana-dashboards-main
+            - grafana-datasources
+            - ingress-exporter-configmap
+            - kibana
+            - prometheus
+            - prometheus-recording-rules
+            - prometheus-rules
+            - prometheus-rules-test-env
+            verbs:
+            - get
           - apiGroups:
             - ""
             resources:


### PR DESCRIPTION
Towads https://github.com/giantswarm/giantswarm/issues/6467

This role allows 
- `list` everything
- `get` everything except draughtsman cm and all secrets