### PR TITLE
PSP for calico-kube-controllers

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1093,6 +1093,40 @@ storage:
 
           ---
 
+          # This manifest creates a clusterrole for the PSP
+          apiVersion: rbac.authorization.k8s.io/v1beta1
+          kind: ClusterRole
+          metadata:
+          name: calico-kube-controllers-psp
+          rules:
+          - apiGroups:
+              - extensions
+            resources:
+              - podsecuritypolicies
+            verbs:
+              - use
+            resourceNames:
+              - calico-kube-controllers-psp
+
+          ---
+
+          # This manifest binds the clusterrole to the SA to
+          # enable the PSP.
+          apiVersion: rbac.authorization.k8s.io/v1beta1
+          kind: ClusterRoleBinding
+          metadata:
+            name: calico-kube-controllers-psp
+          subjects:
+            - kind: ServiceAccount
+              name: calico-kube-controllers
+              namespace: kube-system
+          roleRef:
+            kind: ClusterRole
+            name: calico-kube-controllers-psp
+            apiGroup: rbac.authorization.k8s.io
+
+          ---
+
           # Calico Version v3.6.1
           # https://docs.projectcalico.org/v3.4/releases#v3.6.1
 

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -47,7 +47,7 @@ storage:
                     "type": "calico",
                     "log_level": "info",
                     "datastore_type": "kubernetes",
-                    "nodename": "__KUBERNETES_NODE_NAME__",          
+                    "nodename": "__KUBERNETES_NODE_NAME__",
                     "mtu": __CNI_MTU__,
                     "ipam": {
                       "type": "host-local",
@@ -1064,6 +1064,32 @@ storage:
           metadata:
             name: calico-kube-controllers
             namespace: kube-system
+
+          ---
+
+          # this manifest applies a PodSecurityPolicy to Calico controllers.
+          apiVersion: extensions/v1beta1
+          kind: PodSecurityPolicy
+          metadata:
+            name: calico-kube-controllers-psp
+          spec:
+            privileged: true
+            fsGroup:
+              rule: RunAsAny
+            runAsUser:
+              rule: RunAsAny
+            runAsGroup:
+              rule: RunAsAny
+            seLinux:
+              rule: RunAsAny
+            supplementalGroups:
+              rule: RunAsAny
+            volumes:
+              - 'secret'
+              - 'hostPath'
+            hostNetwork: true
+            hostIPC: false
+            hostPID: false
 
           ---
 
@@ -2387,7 +2413,7 @@ storage:
             done
 
             # label namespaces (required for network egress policies)
-            NAMESPACES="default giantswarm giantswarm-clusterapi kube-system" 
+            NAMESPACES="default giantswarm giantswarm-clusterapi kube-system"
             for namespace in ${NAMESPACES}
             do
                 if ! $KUBECTL get namespaces -l name=${namespace} | grep ${namespace}; then
@@ -3059,7 +3085,7 @@ storage:
     - path: /etc/sysctl.d/hardening.conf
       filesystem: root
       mode: 0600
-      contents: 
+      contents:
         inline: |
           fs.inotify.max_user_watches = 16384
           kernel.kptr_restrict = 2

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1003,6 +1003,9 @@ storage:
                   - key: node-role.kubernetes.io/master
                     effect: NoSchedule
                 serviceAccountName: calico-kube-controllers
+                securityContext:
+                  runAsUser: 0
+                  runAsGroup: 0
                 priorityClassName: system-cluster-critical
                 containers:
                   - name: calico-kube-controllers


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/6013

This PR still allows the pod to run as root as this is required to read certs from the hostPath dir. A later PR should address this.

This has been tested by manually applying the role/bindings/psp on gauss.