### PR TITLE
remove ns from clusterrole

### DIFF
--- a/templates/files/k8s-resource/rbac-roles.yaml
+++ b/templates/files/k8s-resource/rbac-roles.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: giantswarm-clusterapi-readonly
-  namespace: giantswarm-clusterapi
   labels:
     scope: control-plane
     type: external


### PR DESCRIPTION
clusterroles are not namespaced, it works, but it ends up without a namespace which could cause confusion and maybe at some point even a break if upstream decides to be stricter in validating on resources