### PR TITLE
ignore errors in the teardown phase

### DIFF
--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -264,7 +264,10 @@ stage-destroy() {
 
   cd ${TFDIR}
   source_bootstrap
-  terraform destroy -force ./
+  # accept that the destroy phase can fail
+  # the pipeline will be considered passed (if the other steps were successful)
+  # and the CI cleaner will get rid of leftovers
+  terraform destroy -force ./ || true
 
   cd -
 }


### PR DESCRIPTION
When running the e2e tests on AWS, if the terraform destroy step fails the test is considered red, without considering the actual test (= kubernetes nodes status) result.
This leads to a high number of false negatives.
IMHO we should ignore any failure in the teardown process and just consider a test successful if the desired nodes are `Running`.
The leftovers on the cloud provider will be removed by the CI cleaner.