### PR TITLE
Use GUID for the Azure Partner Program

### DIFF
--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -3,6 +3,7 @@ provider "azurerm" {
   version = "~> 1.33.0"
 
   environment = "${var.azure_cloud}"
+  partner_id  = "${var.azure_sp_partnerid}"
 }
 
 locals {

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -31,6 +31,11 @@ variable "azure_sp_subscriptionid" {
   description = "Subscription ID of Service Principal for Kubernetes"
 }
 
+variable "azure_sp_partnerid" {
+  type        = "string"
+  description = "Partner ID used for the Azure Partner Program."
+}
+
 variable "azure_sp_aadclientid" {
   type        = "string"
   description = "ID of Service Principal for Kubernetes"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7475

According [to the docs](https://docs.microsoft.com/en-us/azure/marketplace/azure-partner-customer-usage-attribution#use-terraform)
> Azure provider for Terraform added a new optional field called partner_id which is where you specify the tracking GUID that you use for your solution.

So I'm adding the GUID to the terraform module, so we can track all the infra created for a customer.