### PR TITLE
Always deploy the delegated DNS zone in terraform

### DIFF
--- a/modules/azure/dns/dns.tf
+++ b/modules/azure/dns/dns.tf
@@ -23,7 +23,7 @@ variable "zone_name" {
 }
 
 resource "azurerm_dns_zone" "dns_zone" {
-  count               = "${var.root_dns_zone_name == "" ? 0 : 1}"
+  count               = "1"
   name                = "${var.zone_name}"
   resource_group_name = "${var.resource_group_name}"
 


### PR DESCRIPTION
Fixed a bug in the terraform module "dns".
See comments in the code.