### PR TITLE
Add cluster-type tag

### DIFF
--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -9,7 +9,7 @@
 locals {
   common_tags = "${map(
     "giantswarm.io/installation", "${var.cluster_name}",
-    "giantswarm.io/installation-type", "control-plane",
+    "giantswarm.io/cluster-type", "control-plane",
     "kubernetes.io/cluster/${var.cluster_name}", "owned"
   )}"
 

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -9,6 +9,7 @@
 locals {
   common_tags = "${map(
     "giantswarm.io/installation", "${var.cluster_name}",
+    "giantswarm.io/installation-type", "control-plane",
     "kubernetes.io/cluster/${var.cluster_name}", "owned"
   )}"
 


### PR DESCRIPTION
This PR https://github.com/giantswarm/aws-operator/pull/2062/files introduced lookup for a control-plane VPC, which works only when there are separate accounts used for control-plane and tenant in aws. In China we have a single account, so filter from here https://github.com/giantswarm/aws-operator/blob/master/service/controller/resource/cpvpc/resource.go#L100-L127 returns multiple records. 

With additional tag it will be easier to get control-plane vpc id