### PR TITLE
jumphost-instance-sizing

### DIFF
--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -71,7 +71,7 @@ variable "s3_bucket_tags" {
 
 variable "bastion_instance_type" {
   type    = string
-  default = "t2.micro"
+  default = "t3.small"
 }
 
 variable "vault_instance_type" {


### PR DESCRIPTION
towards PM https://github.com/giantswarm/giantswarm/issues/7729

we had some issues on gridscale jumphost when they were super small as the ssh  service got killed. so let's try to use t3 instances and add some extra resources

next step would be adding node-exporter service on bastions