### PR TITLE
Make OIDC disabled by default

### DIFF
--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -114,6 +114,7 @@ locals {
     "MasterCount"                  = "${var.master_count}"
     "MasterMountDocker"            = "${var.master_instance["volume_docker"]}"
     "MasterMountETCD"              = "${var.master_instance["volume_etcd"]}"
+    "OIDCEnabled"                  = "${var.oidc_enabled}"
     "PodInfraImage"                = "${var.pod_infra_image}"
     "Provider"                     = "aws"
     "Users"                        = "${file("${path.module}/../../../ignition/users.yaml")}"

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -225,6 +225,14 @@ variable "subnets_worker" {
   default     = ["10.0.5.0/26", "10.0.5.64/26", "10.0.5.128/26"]
 }
 
+### OIDC ###
+
+variable "oidc_enabled" {
+  description = "Configure OIDC flags for Kubernetes API server"
+  default = false
+  type = bool
+}
+
 ### VPN ###
 
 variable "aws_customer_gateway_id_0" {

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -97,6 +97,7 @@ locals {
     "LogentriesPrefix"         = "${var.logentries_prefix}"
     "LogentriesToken"          = "${var.logentries_token}"
     "MasterCount"              = "${var.master_count}"
+    "OIDCEnabled"              = "${var.oidc_enabled}"
     "PodCIDR"                  = "${var.pod_cidr}"
     "Provider"                 = "azure"
     "Users"                    = "${file("${path.module}/../../../ignition/users.yaml")}"

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -212,6 +212,14 @@ variable "k8s_audit_webhook_port" {
   default     = "30771"
 }
 
+### OIDC ###
+
+variable "oidc_enabled" {
+  description = "Configure OIDC flags for Kubernetes API server"
+  default = false
+  type = bool
+}
+
 ### VPN ###
 
 # NOTE: VPN is disabled by default.

--- a/templates/files/manifests/api-server.yaml
+++ b/templates/files/manifests/api-server.yaml
@@ -54,10 +54,12 @@ spec:
       - --audit-log-maxbackup=30
       - --audit-log-maxsize=100
       - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+      {{ if .OIDCEnabled }}
       - --oidc-issuer-url=https://dex.{{ .APIDomainName }}
       - --oidc-client-id=dex-k8s-authenticator
       - --oidc-username-claim=email
       - --oidc-groups-claim=groups
+      {{ end }}
       - --requestheader-client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
       - --requestheader-allowed-names=aggregator,api.{{ .APIDomainName }},worker.{{ .APIDomainName }}
       - --requestheader-extra-headers-prefix=X-Remote-Extra-

--- a/templates/files/manifests/api-server.yaml
+++ b/templates/files/manifests/api-server.yaml
@@ -54,12 +54,12 @@ spec:
       - --audit-log-maxbackup=30
       - --audit-log-maxsize=100
       - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
-      {{ if .OIDCEnabled }}
+      {{ if .OIDCEnabled -}}
       - --oidc-issuer-url=https://dex.{{ .APIDomainName }}
       - --oidc-client-id=dex-k8s-authenticator
       - --oidc-username-claim=email
       - --oidc-groups-claim=groups
-      {{ end }}
+      {{ end -}}
       - --requestheader-client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
       - --requestheader-allowed-names=aggregator,api.{{ .APIDomainName }},worker.{{ .APIDomainName }}
       - --requestheader-extra-headers-prefix=X-Remote-Extra-


### PR DESCRIPTION
Enabled by default doesn't cause any issues, but drops unwanted error messages in logs.