### PR TITLE
rollbakc to 1.15

### DIFF
--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -116,7 +116,7 @@ variable "docker_registry" {
 
 variable "hyperkube_version" {
   type    = string
-  default = "v1.16.7"
+  default = "v1.15.4"
 }
 
 ### DNS ###

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -123,7 +123,7 @@ variable "docker_registry" {
 }
 variable "hyperkube_version" {
   type    = string
-  default = "v1.16.7"
+  default = "v1.15.4"
 }
 
 ### DNS ###


### PR DESCRIPTION
most of CP uses old api versions for psp and deployments, we cannot upgrade