### PR TITLE
Fix deployment specs for new k8s

### DIFF
--- a/templates/files/k8s-resource/calico-all.yaml
+++ b/templates/files/k8s-resource/calico-all.yaml
@@ -1096,6 +1096,9 @@ metadata:
 spec:
   # The controllers can only have a single active instance.
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
   strategy:
     type: Recreate
   template:

--- a/templates/files/k8s-resource/default-backend-dep.yaml
+++ b/templates/files/k8s-resource/default-backend-dep.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     k8s-app: default-http-backend
 spec:
+  selector:
+    matchLabels:
+      k8s-app: default-http-backend
   replicas: 2
   template:
     metadata:

--- a/templates/files/k8s-resource/ingress-controller-dep.yaml
+++ b/templates/files/k8s-resource/ingress-controller-dep.yaml
@@ -9,6 +9,9 @@ metadata:
     prometheus.io/port: '10254'
     prometheus.io/scrape: 'true'
 spec:
+  selector:
+    matchLabels:
+      k8s-app: nginx-ingress-controller
   replicas: 3
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
This was missed during the update to k8s 1.16 as those resources were already there.

P.S. @calvix maybe worth to check hive repo as well as you would get into same issue there with new installation