### PR TITLE
fix-asg-calico

### DIFF
--- a/templates/files/k8s-resource/calico-all.yaml
+++ b/templates/files/k8s-resource/calico-all.yaml
@@ -960,6 +960,8 @@ spec:
               value: "warn"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: IP_AUTODETECTION_METHOD
+              value: skip-interface=eth1
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
calico is acting weird on nodes with 2 interfaces from the same network, ignoring eth1 is fixing the issue