### PR TITLE
improve-image-pulling-in-china

### DIFF
--- a/templates/files/config/kubelet-master.yaml.tmpl
+++ b/templates/files/config/kubelet-master.yaml.tmpl
@@ -26,5 +26,5 @@ authorization:
   mode: AlwaysAllow # Deafults to webhook as of 1.10
 # improve image pulls in china
 serializeImagePulls: false
-registryPullQPS: 10
-registryBurst: 20
+registryPullQPS: 2
+registryBurst: 3

--- a/templates/files/config/kubelet-master.yaml.tmpl
+++ b/templates/files/config/kubelet-master.yaml.tmpl
@@ -24,3 +24,7 @@ authentication:
     enabled: false # Deafults to true as of 1.10
 authorization:
   mode: AlwaysAllow # Deafults to webhook as of 1.10
+# improve image pulls in china
+serializeImagePulls: false
+registryPullQPS: 10
+registryBurst: 20

--- a/templates/files/config/kubelet-worker.yaml.tmpl
+++ b/templates/files/config/kubelet-worker.yaml.tmpl
@@ -23,3 +23,7 @@ authentication:
     enabled: false # Defaults to true as of 1.10
 authorization:
   mode: AlwaysAllow # Defaults to webhook as of 1.10
+# improve image pulls in china
+serializeImagePulls: false
+registryPullQPS: 10
+registryBurst: 20

--- a/templates/files/config/kubelet-worker.yaml.tmpl
+++ b/templates/files/config/kubelet-worker.yaml.tmpl
@@ -25,5 +25,5 @@ authorization:
   mode: AlwaysAllow # Defaults to webhook as of 1.10
 # improve image pulls in china
 serializeImagePulls: false
-registryPullQPS: 10
-registryBurst: 20
+registryPullQPS: 2
+registryBurst: 3


### PR DESCRIPTION
enable parallel pulls and add some config values

this helped axolotl and giraffe start much faster even with some bad quay images ( legacy aws-operator)

basically slow quay pull won't slow other images

should be probably imported also to TC 