### PR TITLE
Force https for storage account

### DIFF
--- a/modules/azure/blob/blob.tf
+++ b/modules/azure/blob/blob.tf
@@ -1,10 +1,11 @@
 resource "azurerm_storage_account" "storage_acc" {
-  name                     = "${var.cluster_name}config"
-  resource_group_name      = var.resource_group_name
-  location                 = var.azure_location
-  account_kind             = "BlobStorage"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                      = "${var.cluster_name}config"
+  resource_group_name       = var.resource_group_name
+  location                  = var.azure_location
+  account_kind              = "BlobStorage"
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  enable_https_traffic_only = true
 }
 
 resource "azurerm_storage_container" "ignition" {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8949

I tested forcing https in the storage account on azure on impala.
It works just fine, so I edited the terraform module in order to force https and address the security hint from azure advisor.