### PR TITLE
Switched to externalTrafficPolicy Cluster 

### DIFF
--- a/templates/files/conf/k8s-addons
+++ b/templates/files/conf/k8s-addons
@@ -125,7 +125,7 @@ MANIFESTS="default-storage-class.yaml
  default-backend-svc.yaml
  ingress-controller-cm.yaml
  ingress-controller-sa.yaml
- ingress-controller-dep.yaml
+ ingress-controller-daemonset.yaml
  ingress-controller-svc.yaml"
 for manifest in $MANIFESTS
 do

--- a/templates/files/k8s-resource/ingress-controller-daemonset.yaml
+++ b/templates/files/k8s-resource/ingress-controller-daemonset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: nginx-ingress-controller
   namespace: kube-system
@@ -12,11 +12,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: nginx-ingress-controller
-  replicas: 3
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -36,6 +31,8 @@ spec:
                     values:
                     - nginx-ingress-controller
               topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/role: worker
       serviceAccountName: nginx-ingress-controller
       priorityClassName: system-cluster-critical
       containers:

--- a/templates/files/k8s-resource/ingress-controller-svc.yaml
+++ b/templates/files/k8s-resource/ingress-controller-svc.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     k8s-app: nginx-ingress-controller
 spec:
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
   type: NodePort
   ports:
   - name: http

--- a/templates/files/k8s-resource/ingress-controller-svc.yaml
+++ b/templates/files/k8s-resource/ingress-controller-svc.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     k8s-app: nginx-ingress-controller
 spec:
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: Local
   type: NodePort
   ports:
   - name: http


### PR DESCRIPTION
The starting point of this funny bug is this PM: https://github.com/giantswarm/giantswarm/issues/9775

The initial symptom: nginx ingress controller not reachable in the control plane when the pods were all scheduled in the master nodes and none in the worker nodes.

The problem is that we use `externalTrafficPolicy: Local` which causes `kube-proxy` to avoid doing NAT on incoming requests. Those requests will fail if the POD is not running in the node where the request is arrived and this ultimately makes the azure load balancer think the node is unhealthy.

Not sure if AWS control planes work and how they do that.

k8s sig network people tells this is intended behaviour, so we have no choice but switch to `externalTrafficPolicy: Cluster` https://github.com/kubernetes/kubernetes/issues/89831