### PR TITLE
[aws] Flatcar Linux (no China)

### DIFF
--- a/modules/flatcar-linux/data/version.sh
+++ b/modules/flatcar-linux/data/version.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+if [ ! "$(command -v jq)" ]; then
+  echo "jq is not installed."
+  exit 1
+fi
+
+eval "$(jq -r '@sh "FLATCAR_CHANNEL=\(.flatcar_channel) FLATCAR_VERSION=\(.flatcar_version) AWS_REGION=\(.aws_region)"')"
+
+if [ "$FLATCAR_VERSION" = "latest" ]; then
+  if [ "$AWS_REGION" != "cn-north-1" ] && [ "$AWS_REGION" != "cn-northwest-1" ]; then
+    version=$(curl -s https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/current/version.txt | sed -n 's/FLATCAR_VERSION=\(.*\)$/\1/p')
+  else
+    version=$(curl -s https://flatcar-prod-ami-import-cn-north-1.s3.cn-north-1.amazonaws.com.cn/version.txt | sed -n 's/FLATCAR_VERSION=\(.*\)$/\1/p')
+  fi
+else
+  version="$FLATCAR_VERSION"
+fi
+
+jq -n --arg version "$version" '{"flatcar_version": $version}'

--- a/modules/flatcar-linux/main.tf
+++ b/modules/flatcar-linux/main.tf
@@ -1,3 +1,10 @@
 data "external" "flatcar_version" {
-  program = ["sh", "-c", "curl https://${var.flatcar_channel}.release.flatcar-linux.net/amd64-usr/current/version.txt | sed -n 's/FLATCAR_VERSION=\\(.*\\)$/{\"flatcar_version\": \"\\1\"}/p'"]
+  program = ["sh", "-c", "${path.module}/data/version.sh"]
+
+  query = {
+    aws_region = "${var.aws_region}"
+
+    flatcar_channel = "${var.flatcar_channel}"
+    flatcar_version = "${var.flatcar_version}"
+  }
 }

--- a/modules/flatcar-linux/main.tf
+++ b/modules/flatcar-linux/main.tf
@@ -1,0 +1,3 @@
+data "external" "flatcar_version" {
+  program = ["sh", "-c", "curl https://${var.flatcar_channel}.release.flatcar-linux.net/amd64-usr/current/version.txt | sed -n 's/FLATCAR_VERSION=\\(.*\\)$/{\"flatcar_version\": \"\\1\"}/p'"]
+}

--- a/modules/flatcar-linux/outputs.tf
+++ b/modules/flatcar-linux/outputs.tf
@@ -1,0 +1,3 @@
+output "flatcar_version" {
+  value = "${var.flatcar_version == "latest" ? data.external.flatcar_version.result["flatcar_version"] : var.flatcar_version}"
+}

--- a/modules/flatcar-linux/variables.tf
+++ b/modules/flatcar-linux/variables.tf
@@ -1,0 +1,19 @@
+variable "flatcar_channel" {
+  type = string
+
+  description = <<EOF
+The Flatcar Linux update channel.
+
+Examples: `stable`, `beta`, `alpha`
+EOF
+}
+
+variable "flatcar_version" {
+  type = string
+
+  description = <<EOF
+The Flatcar Linux version to use. Set to `latest` to select the latest available version for the selected update channel.
+
+Examples: `latest`, `1465.6.0`
+EOF
+}

--- a/modules/flatcar-linux/variables.tf
+++ b/modules/flatcar-linux/variables.tf
@@ -1,3 +1,9 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS Region used to differentiate with AWS China where image version is pulled from a different location."
+}
+
+
 variable "flatcar_channel" {
   type = string
 

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -24,6 +24,8 @@ module "container_linux" {
 module "flatcar_linux" {
   source = "../../../modules/flatcar-linux"
 
+  aws_region = "${var.aws_region}"
+
   flatcar_channel = "${var.flatcar_linux_channel}"
   flatcar_version = "${var.flatcar_linux_version}"
 }

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -113,6 +113,25 @@ variable "container_linux_version" {
   default     = "latest"
 }
 
+### Flatcar Linux ###
+variable "flatcar_linux_channel" {
+  description = "Flatcar linux channel (e.g. stable, beta, alpha)."
+  default     = "stable"
+}
+
+
+## If explicity set it up, Flatcar will be used installed instead of CoreOS
+variable "flatcar_linux_version" {
+  description = "Flatcar linux version."
+  type        = "string"
+  default     = null
+}
+
+variable "flatcar_ami_owner" {
+  description = "Flatcar linux AWS ID account."
+  default     = "075585003325"
+}
+
 variable "docker_registry" {
   type    = string
   default = "quay.io"

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -123,7 +123,7 @@ variable "flatcar_linux_channel" {
 ## If explicity set it up, Flatcar will be used installed instead of CoreOS
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
-  type        = "string"
+  type        = string
   default     = null
 }
 


### PR DESCRIPTION
This PR introduces to the GS CP Flatcar.

I've opted for the current approach. If it is not set it up explicitly `flatcar_linux_version`, CoreOS is still used as OS for all CP compoments.

This covers only AWS. For Azure we need to refactor even more, because unfortunately the abstraction is not so powerful. Azure modules indeed explicitly define as publisher `CoreOS`. oh well let's leave this discussion for a different PR.

I've already executed `terraform plan` and it works. Need to run `apply` to create `galileo` as first CP with Flatcar Linux.