### PR TITLE
Append prefix to S3 bucket

### DIFF
--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 resource "aws_s3_bucket" "logging" {
-  bucket        = "${var.cluster_name}-access-logs"
+  bucket        = "${var.aws_account}-${var.cluster_name}-access-logs"
   acl           = "log-delivery-write"
   force_destroy = true
 
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "logging" {
   tags = merge(
     local.common_tags,
     map(
-      "Name", "${var.cluster_name}-access-logs"
+      "Name", "${var.aws_account}-${var.cluster_name}-access-logs"
     )
   )
 }


### PR DESCRIPTION
We stumbled upon an annoying issue.

```
Error: Error creating S3 bucket: BucketAlreadyExists: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.
```

The bucket `galileo-access-logs` already exists in AWS Global.

----

This change, despite small, can have some implications. 

I'd need some help to verify the impact of this change.

For our CPs I believe this is not a big deal. But changing the name of the bucket here forces new resource hence a new bucket. Hence deploying this would create a new bucket. I believe is a breaking change but cannot really say the grade of impact.

Our customers access to those ELB logs? Do we process them? Do we rely anyhow?
