### PR TITLE
'add-optional-s3bucket-prefix'

### DIFF
--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -6,12 +6,12 @@ locals {
 }
 
 resource "aws_s3_bucket" "logging" {
-  bucket        = "${var.cluster_name}-access-logs"
+  bucket        = "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
   acl           = "log-delivery-write"
   force_destroy = true
 
   logging {
-    target_bucket = "${var.cluster_name}-access-logs"
+    target_bucket = "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
     target_prefix = "self-logs/"
   }
 
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "logging" {
   tags = merge(
     local.common_tags,
     map(
-      "Name", "${var.cluster_name}-access-logs"
+      "Name", "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
     )
   )
 }
@@ -47,7 +47,7 @@ resource "aws_s3_bucket" "ignition" {
 
   logging {
     target_bucket = aws_s3_bucket.logging.id
-    target_prefix = "${var.cluster_name}-ignition-logs/"
+    target_prefix = "${var.s3_bucket_prefix}${var.cluster_name}-ignition-logs/"
   }
 
   server_side_encryption_configuration {

--- a/modules/aws/s3/variables.tf
+++ b/modules/aws/s3/variables.tf
@@ -9,3 +9,7 @@ variable "cluster_name" {
 variable "logs_expiration_days" {
   type = string
 }
+
+variable "s3_bucket_prefix" {
+  type = string
+}

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -80,6 +80,7 @@ module "s3" {
   aws_account          = "${var.aws_account}"
   cluster_name         = "${var.cluster_name}"
   logs_expiration_days = "${var.logs_expiration_days}"
+  s3_bucket_prefix     = "${var.s3_bucket_prefix}"
 }
 
 locals {

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -63,6 +63,10 @@ variable "logs_expiration_days" {
   default     = "365"
 }
 
+variable "s3_bucket_prefix" {
+  default = ""
+}
+
 variable "s3_bucket_tags" {
   default = true
 }


### PR DESCRIPTION
fixing the aftermatch after his PR https://github.com/giantswarm/giantnetes-terraform/pull/318
caused that ginger access logs s3 bucket was deleted but due to life-cycle policy to 365 days the logs will be available and s3 bucket name is not available to use

so adding an optional prefix to fix possible name conflicts and have ginger back to working state

ginger will have this in the bootstrap:
```
export TF_VAR_s3_bucket_prefix="giantswarm-"
```