### PR TITLE
Make flatcar default for AWS installations

### DIFF
--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -124,7 +124,7 @@ variable "flatcar_linux_channel" {
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
   type        = string
-  default     = null
+  default     = "2345.3.1"
 }
 
 variable "flatcar_ami_owner" {


### PR DESCRIPTION
I've deployed Flatcar in China installations already. 
Also CoreOS eol has come. 
So let's move further