### PR TITLE
Remove dockershim and dockersock mounts from aws-node

### DIFF
--- a/templates/files/k8s-resource/aws-cni.yaml
+++ b/templates/files/k8s-resource/aws-cni.yaml
@@ -159,10 +159,6 @@ spec:
               name: cni-net-dir
             - mountPath: /host/var/log
               name: log-dir
-            - mountPath: /var/run/docker.sock
-              name: dockersock
-            - mountPath: /var/run/dockershim.sock
-              name: dockershim
       volumes:
         - name: cni-bin-dir
           hostPath:
@@ -173,12 +169,6 @@ spec:
         - name: log-dir
           hostPath:
             path: /var/log
-        - name: dockersock
-          hostPath:
-            path: /var/run/docker.sock
-        - name: dockershim
-          hostPath:
-            path: /var/run/dockershim/dockershim.sock
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11457

These mounts are not needed for aws-node v1.6.0 and newer.