### PR TITLE
setup-kubelet-environment: remove env file before writing

### DIFF
--- a/templates/files/conf/setup-kubelet-environment
+++ b/templates/files/conf/setup-kubelet-environment
@@ -310,4 +310,5 @@ esac
 MAX_PODS=110
 {{ end }}
 
+rm -f ${env_file}
 echo "MAX_PODS=${MAX_PODS}" >> ${env_file}


### PR DESCRIPTION
This is to avoid the situation where values are appended again after
reboot.