### PR TITLE
Add Microsoft.Storage service endpoint to worker subnet

### DIFF
--- a/modules/azure/vnet/vnet-subnets.tf
+++ b/modules/azure/vnet/vnet-subnets.tf
@@ -62,6 +62,9 @@ resource "azurerm_subnet" "worker_subnet" {
   # Same for rt association 
   # https://www.terraform.io/docs/providers/azurerm/r/subnet_route_table_association.html
   route_table_id = azurerm_route_table.worker_rt.id
+
+  # We need the storage service endpoint to grant the control plane VNET access to the TC's storage accounts
+  service_endpoints = ["Microsoft.Storage"]
 }
 
 resource "azurerm_subnet_route_table_association" "worker" {


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/11499

we need to add the Microsoft.Storage `service endpoint` to the workers subnet to be able to allow the control plane to access storage accounts in the TC's resource groups