### PR TITLE
reduce-aws-cni-warm-ip

### DIFF
--- a/misc/e2e-aws.sh
+++ b/misc/e2e-aws.sh
@@ -22,7 +22,7 @@ WORKDIR=$(pwd)
 TFDIR=${WORKDIR}/platforms/aws/giantnetes
 CLUSTER=e2etf-$(echo ${CIRCLE_SHA1} | cut -c 1-4)
 SSH_USER="e2e"
-KUBECTL_CMD="sudo /opt/bin/hyperkube kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml"
+KUBECTL_CMD="sudo /opt/bin/kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml"
 
 WORKER_COUNT=1
 

--- a/misc/e2e-azure.sh
+++ b/misc/e2e-azure.sh
@@ -22,7 +22,7 @@ WORKDIR=$(pwd)
 TFDIR=${WORKDIR}/platforms/azure/giantnetes
 CLUSTER=e2etf$(echo ${CIRCLE_SHA1} | cut -c 1-5)
 SSH_USER="e2e"
-KUBECTL_CMD="sudo /opt/bin/hyperkube kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml"
+KUBECTL_CMD="sudo /opt/bin/kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml"
 WORKER_COUNT=1
 ROOT_DNS_ZONE_RESOURCEGROUP_NAME="root_dns_zone_rg"
 ROOT_DNS_ZONE="azure.gigantic.io"

--- a/templates/files/k8s-resource/aws-cni.yaml
+++ b/templates/files/k8s-resource/aws-cni.yaml
@@ -136,9 +136,9 @@ spec:
             ## Deviation from original manifest - 4
             ## prewarm IP to limit AWS api calls
             - name: WARM_IP_TARGET
-              value: "10"
-            - name: MINIMUM_IP_TARGET
               value: "5"
+            - name: MINIMUM_IP_TARGET
+              value: "2"
             ## Deviation from original manifest - 5
             ## disable SNAT as we setup NATGW in the route tables
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT


### PR DESCRIPTION
 this can help when the cluster is auto-scaling a lot to speed up process but the problem is that it will waste IPs on  each node so big number can lead to unused assigned IP and in small subnets lead to exhaustion of subnets