### PR TITLE
templates: make k8s-setup-delete-old-node work by best effort

### DIFF
--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1027,8 +1027,6 @@ systemd:
       RemainAfterExit=yes
       TimeoutStartSec=0
       Environment="KUBECTL=/opt/bin/kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
-      # Make sure kubectl works and can get nodes because exit code is ignored in ExecStart.
-      ExecStartPre=/bin/sh -c '$$KUBECTL get node'
       # "-" at the front of the command makes unit ignore non-zero exit code.
       ExecStart=-/bin/sh -c '$$KUBECTL delete node $(hostname | tr "[:upper:]" "[:lower:]")'
       [Install]

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -485,8 +485,6 @@ systemd:
       RemainAfterExit=yes
       TimeoutStartSec=0
       Environment="KUBECTL=/opt/bin/kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
-      # Make sure kubectl works and can get nodes because exit code is ignored in ExecStart.
-      ExecStartPre=/bin/sh -c '$$KUBECTL get node'
       # "-" at the front of the command makes unit ignore non-zero exit code.
       ExecStart=-/bin/sh -c '$$KUBECTL delete node $(hostname | tr "[:upper:]" "[:lower:]")'
       [Install]


### PR DESCRIPTION
There are situations where K8s API is not available when the node
starts. E.g. setting up a fresh cluster.

This now will only try to remove the node to mitigate the original
issue.

See https://github.com/giantswarm/giantnetes-terraform/pull/338#issuecomment-652511824