### PR TITLE
Check calico with retries

### DIFF
--- a/templates/files/conf/k8s-addons
+++ b/templates/files/conf/k8s-addons
@@ -109,9 +109,9 @@ done
 
 echo "Waiting for calico-node to be ready..."
 n=0
-until [ "$n" -ge 10 ] || [ ! "$exitcode" -eq 0 ]
+until [ "$n" -ge 10 ] || [ "$exitcode" -eq 0 ]
 do
-   $KUBECTL -n kube-system -l k8s-app=calico-node wait --for=condition=Ready --timeout=30s pods
+   kubectl -n kube-system -l k8s-app=calico-node wait --for=condition=Ready --timeout=30s pods
    exitcode=$?
    n=$((n+1)) 
    sleep 10

--- a/templates/files/conf/k8s-addons
+++ b/templates/files/conf/k8s-addons
@@ -109,6 +109,7 @@ done
 
 echo "Waiting for calico-node to be ready..."
 n=0
+exitcode=-1
 until [ "$n" -ge 10 ] || [ "$exitcode" -eq 0 ]
 do
    kubectl -n kube-system -l k8s-app=calico-node wait --for=condition=Ready --timeout=30s pods

--- a/templates/files/conf/k8s-addons
+++ b/templates/files/conf/k8s-addons
@@ -108,7 +108,14 @@ do
 done
 
 echo "Waiting for calico-node to be ready..."
-$KUBECTL -n kube-system -l k8s-app=calico-node wait --for=condition=Ready --timeout=15m pods
+n=0
+until [ "$n" -ge 10 ] || [ ! "$exitcode" -eq 0 ]
+do
+   $KUBECTL -n kube-system -l k8s-app=calico-node wait --for=condition=Ready --timeout=30s pods
+   exitcode=$?
+   n=$((n+1)) 
+   sleep 10
+done
 
 # delete calico-kube-controllers
 $KUBECTL -n kube-system delete deploy calico-kube-controllers --ignore-not-found=true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11236

For now kubectl wait hangs at some point due to timeout accessing API and never retries again. That's why it fails eventually