### PR TITLE
Avoid setting plan for azure vault instances still running coreOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `vault-token-reviewer` service account and cluster-role binding.
 
+### Changed
+
+- Avoid using the 'plan' option in the vault VM in Azure when CoreOS is still in use.
+
 ## [1.0.4] - 2020-08-03
 
 ### Fixed

--- a/modules/azure/vault/variables.tf
+++ b/modules/azure/vault/variables.tf
@@ -6,6 +6,16 @@ variable "flatcar_linux_version" {
   type = string
 }
 
+variable "image_publisher" {
+  type = string
+  default = "kinvolk"
+}
+
+variable "image_offer" {
+  type = string
+  default = "flatcar-container-linux-free"
+}
+
 variable "core_ssh_key" {
   description = "ssh key for user core"
   type        = string

--- a/modules/azure/vault/vault.tf
+++ b/modules/azure/vault/vault.tf
@@ -34,16 +34,20 @@ resource "azurerm_virtual_machine" "vault" {
   delete_data_disks_on_termination = false
 
   storage_image_reference {
-    publisher = "kinvolk"
-    offer     = "flatcar-container-linux-free"
+    publisher = var.image_publisher
+    offer     = var.image_offer
     sku       = var.flatcar_linux_channel
     version   = var.flatcar_linux_version
   }
 
-  plan {
-    name = var.flatcar_linux_channel
-    publisher = "kinvolk"
-    product = "flatcar-container-linux-free"
+  # The plan needs to be added only if we use Flatcar.
+  dynamic "plan" {
+    for_each = var.image_publisher == "kinvolk" ? [1] : []
+    content {
+      name = var.flatcar_linux_channel
+      publisher = var.image_publisher
+      product = "flatcar-container-linux-free"
+    }
   }
 
   storage_os_disk {

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -140,6 +140,8 @@ module "vault" {
   cluster_name          = "${var.cluster_name}"
   flatcar_linux_channel = "${var.flatcar_linux_channel}"
   flatcar_linux_version = "${module.flatcar_linux.flatcar_version}"
+  image_publisher       = "${var.vault_image_publisher}"
+  image_offer           = "${var.vault_image_offer}"
   core_ssh_key          = "${var.core_ssh_key}"
   location              = "${var.azure_location}"
   network_interface_ids = "${module.vnet.vault_network_interface_ids}"

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -113,6 +113,16 @@ variable "flatcar_linux_version" {
   default     = "2345.3.1"
 }
 
+variable "vault_image_publisher" {
+  type = string
+  default = "kinvolk"
+}
+
+variable "vault_image_offer" {
+  type = string
+  default = "flatcar-container-linux-free"
+}
+
 variable "core_ssh_key" {
   description = "ssh key for user core"
   default     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIvW4h8X48R38jYIkod5whXMhIL/9Zfgp+EwgkRZi4mn+OAbCprHwc4V3RUGW0ysEdEqI/4FI1ho57X8CbbLa03MazNCKHCd8CNGdGorKai0g4uRaJI4wp+J6wniqERdJjuRKvRVYEZt8Ptv7YS0i3uW2HUDPVipkEqmSUtF7t4lAD1FDtAGQN23bdDhWHfTUAfg5yooiHtm9JfKiEV7MwncMd1nlZIklJWMQf9W5dvJBPmhVU0XmaCsmOH2rvaCi+cZQiMCqJOBKzDnEupanGcaf76iCQ3dn1ToCxXLlnRvhgSL6thR9HC3vA/ivDReKO7BXB8FVuZnr7NT0oxGaz fake"


### PR DESCRIPTION
This PR aims at restoring the functionality of the conveyor pipelines on azure.

Currently the conveyor job assumes that we are using `flatcar linux` in all virtual machines in an azure installation.
This is not true, as most installations still have coreOS in their vault instance.

This PR adds 2 new variables and the `plan` section of the vault VM resource is now dynamic based on the actual image used.

The default behaviour is to use flatcar (in new installations) and can be overridden by setting appropriate variable values overrides in the `installations` repo.