### PR TITLE
Allow scraping of TCs for TC prometheus

### DIFF
--- a/templates/files/k8s-resource/aws-cni.yaml
+++ b/templates/files/k8s-resource/aws-cni.yaml
@@ -140,10 +140,6 @@ spec:
             - name: MINIMUM_IP_TARGET
               value: "2"
             ## Deviation from original manifest - 5
-            ## disable SNAT as we setup NATGW in the route tables
-            - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
-              value: "true"
-            ## Deviation from original manifest - 6
             ## Explicit interface naming
             - name: AWS_VPC_K8S_CNI_VETHPREFIX
               value: eni

--- a/templates/files/k8s-resource/aws-cni.yaml
+++ b/templates/files/k8s-resource/aws-cni.yaml
@@ -143,6 +143,9 @@ spec:
             ## Explicit interface naming
             - name: AWS_VPC_K8S_CNI_VETHPREFIX
               value: eni
+            ## Disable SNAT as we setup NATGW in the route tables	
+            - name: AWS_VPC_K8S_CNI_EXTERNALSNAT	
+              value: "false"
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
To allow our tenant cluster Prometheus to be able to scrape tenant clusters, we need to set the AWS_VPC_K8S_CNI_EXTERNALSNAT to false as otherwise as the POD CIDR of the tenant cluster prometheus server would not be allowed to talk with the tenant cluster. 
This was solved using hostNetwork: true for g8s-prometheus but this property is unusable with the prometheus operator as per https://github.com/prometheus-operator/prometheus-operator/issues/2630