### PR TITLE
Add note about enabling versioning for terraform storage account

### DIFF
--- a/docs/installation-guide-azure.md
+++ b/docs/installation-guide-azure.md
@@ -56,6 +56,9 @@ Get access key it will be needed in the next step.
 az storage account keys list -g ${NAME}-terraform  --account-name ${NAME}terraform
 ```
 
+Enable versioning: go to the azure portal, navigate to the resource group `${NAME}-terraform`, then to the storage account `${NAME}terraform`.
+In the left menu, click on `Data protection`, select the `Turn on versioning` checkbox and click `Save`.
+
 ### Create service principal
 
 Create resource group for cluster. We need one to assign permissions.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10361

This PR adds a note in the azure installation documentation to enable versioning in the storage account used to store terraform state.

Note: this is impossible to do via the API, the portal is the only choice.