### PR TITLE
Make docker pull optional before run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Do not fail k8s-setup-network-env if docker pull fails.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not fail k8s-setup-network-env if docker pull fails.
+
 ## [1.4.0] - 2020-09-16
 
 ### Changed

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -750,9 +750,9 @@ systemd:
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/mkdir -p /opt/bin/
-      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStart=/usr/bin/docker run --rm --net=host -v /etc:/etc --name $NAME $IMAGE --verbose
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -750,7 +750,7 @@ systemd:
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/mkdir -p /opt/bin/
-      ExecStartPre=- /usr/bin/docker pull $IMAGE
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/usr/bin/docker run --rm --net=host -v /etc:/etc --name $NAME $IMAGE --verbose

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -750,7 +750,6 @@ systemd:
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/mkdir -p /opt/bin/
-      ExecStartPre=/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/usr/bin/docker run --rm --net=host -v /etc:/etc --name $NAME $IMAGE --verbose
@@ -915,7 +914,6 @@ systemd:
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
-      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-crt.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
@@ -967,7 +965,6 @@ systemd:
       Environment=NAME=%p.service
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
-      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStart=/usr/bin/docker run \
         -v /etc/kubernetes/ssl/etcd/:/etc/etcd \
         --net=host  \
@@ -1220,11 +1217,11 @@ networkd:
       Name=eth1
       [Network]
       Address={{.MasterENIAddress}}/{{.MasterENISubnetSize}}
-      
+
       [RoutingPolicyRule]
       Table=2
       From={{.MasterENIAddress}}/32
-      
+
       [Route]
       Destination=0.0.0.0/0
       Gateway={{.MasterENIGateway}}

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -750,6 +750,7 @@ systemd:
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/mkdir -p /opt/bin/
+      ExecStartPre=- /usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/usr/bin/docker run --rm --net=host -v /etc:/etc --name $NAME $IMAGE --verbose
@@ -914,6 +915,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-crt.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
@@ -965,6 +967,7 @@ systemd:
       Environment=NAME=%p.service
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStart=/usr/bin/docker run \
         -v /etc/kubernetes/ssl/etcd/:/etc/etcd \
         --net=host  \


### PR DESCRIPTION
~~This is a somewhat controversial change:~~
~~Instead of pulling the image on every restart of the unit, we rely on `docker run` to pull it once and then use the local image.~~

~~Pro: We pull less often and it hopefully makes us a bit more tolerant to slow / flaky network,~~

~~Con: We have to use properly tagged images and ensure the correct image is actually on the machine.~~

Decided to make all docker pulls  not fail the unit itself.

Towards https://github.com/giantswarm/giantswarm/issues/12928