### PR TITLE
Change etcd disk size to 64gb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Changed the ETCD disk size to 64Gb on azure to have a higher provisioned IOPS.
+
 ## [1.5.0] - 2020-10-09
 
 ### Added

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -70,7 +70,7 @@ variable "docker_disk_size" {
 variable "etcd_disk_size" {
   type        = string
   description = "Size of data disk in GB."
-  default     = "10"
+  default     = "64"
 }
 
 variable "api_backend_address_pool_id" {


### PR DESCRIPTION
This PR changes the etcd disk size for azure CPs to 64GBs.
On azure, the IOPS for disks are based on the disk size, and 64 is the smallest size we can use to have access to the following level of IOPS (240, currently 120).

This is important because we're hitting the IOPS limit and this is causing the master nodes to crash.