### PR TITLE
Updating calico policy only deployment to apps/v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update calico-policy-only deployment version to apps/v1
+
 ## [2.0.0] - 2020-10-26
 
 ### Changed

--- a/templates/files/k8s-resource/calico-policy-only.yaml
+++ b/templates/files/k8s-resource/calico-policy-only.yaml
@@ -81,7 +81,7 @@ spec:
 
 # This manifest creates a Deployment of Typha to back the above service.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -97,6 +97,9 @@ spec:
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 0
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:


### PR DESCRIPTION
calico-policy-only.yaml deployment needs to be updated to apps/v1

PM: https://github.com/giantswarm/giantswarm/issues/14006