### PR TITLE
add server-tokens: "false" to IC config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `server-tokens: "false"` to Nginx Ingress Controller to remove the server tokens from the default backend response body and answer.
+
 ### Deleted
 
 - Delete Kubernetes API readonly role/binding.

--- a/templates/files/k8s-resource/ingress-controller-cm.yaml
+++ b/templates/files/k8s-resource/ingress-controller-cm.yaml
@@ -13,4 +13,5 @@ data:
   variables-hash-bucket-size: "128"
   server-name-hash-bucket-size: "1024"
   server-name-hash-max-size: "1024"
+  server-tokens: "false"
   worker-processes: "4"


### PR DESCRIPTION
When you hit a non-existing endpoint on CP, the default backend is adding their server token in the headers and on the default HTML.
This is recognized as a security issue.

Adding server-tokens: "false" will remove it. IT's already in place in TC