### PR TITLE
Changed default VM size for azure master nodes to Standard_D4s_v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `server-tokens: "false"` to Nginx Ingress Controller to remove the server tokens from the default backend response body and answer.
 
+### Changed
+
+- Changed default VM size for azure master nodes to Standard_D4s_v3.
+
 ### Deleted
 
 - Delete Kubernetes API readonly role/binding.

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -93,7 +93,7 @@ variable "vault_storage_type" {
 
 variable "master_vm_size" {
   type    = string
-  default = "Standard_D2s_v3"
+  default = "Standard_D4s_v3"
 }
 
 variable "master_storage_type" {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13978

We decided to increate VM size for master nodes on azure because sometimes they can't keep the pace with the requested load.