### PR TITLE
Restrict cluster autoscaler required policy

### DIFF
--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -102,7 +102,7 @@ resource "aws_iam_role_policy" "master" {
            "autoscaling:SetDesiredCapacity",
            "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
-        "Resource": "arn:${var.arn_region}:autoscaling:${var.iam_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
+        "Resource": "arn:${var.arn_region}:autoscaling:${var.aws_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
         "Effect": "Allow"
       }
   ]

--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -100,7 +100,7 @@ resource "aws_iam_role_policy" "master" {
       {
         "Action": [
            "autoscaling:SetDesiredCapacity",
-           "autoscaling:TerminateInstanceInAutoScalingGroup",
+           "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
         "Resource": "arn:${var.arn_region}:autoscaling:${var.iam_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
         "Effect": "Allow"

--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -92,11 +92,17 @@ resource "aws_iam_role_policy" "master" {
            "autoscaling:DescribeAutoScalingInstances",
            "autoscaling:DescribeLaunchConfigurations",
            "autoscaling:DescribeTags",
-           "autoscaling:SetDesiredCapacity",
-           "autoscaling:TerminateInstanceInAutoScalingGroup",
            "ec2:DescribeLaunchTemplateVersions"
         ],
         "Resource": "*",
+        "Effect": "Allow"
+      },
+      {
+        "Action": [
+           "autoscaling:SetDesiredCapacity",
+           "autoscaling:TerminateInstanceInAutoScalingGroup",
+        ],
+        "Resource": "arn:${var.arn_region}:autoscaling:${var.iam_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
         "Effect": "Allow"
       }
   ]

--- a/modules/aws/master/variables.tf
+++ b/modules/aws/master/variables.tf
@@ -14,6 +14,10 @@ variable "aws_account" {
   type = string
 }
 
+variable "aws_region" {
+  type = string
+}
+
 variable "aws_cni_cidr_block" {
   type = string
 }

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -26,7 +26,6 @@ resource "aws_cloudformation_stack" "worker_asg" {
           "${var.cluster_name}-worker"
         ],
         "MaxSize": "${var.worker_count * 2}",
-        "DesiredCapacity": "${var.worker_count}",
         "MinSize": "${var.worker_count}",
         "Tags": [
           {

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -123,7 +123,7 @@ resource "aws_iam_role_policy" "worker" {
            "autoscaling:SetDesiredCapacity",
            "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
-        "Resource": "arn:${var.arn_region}:autoscaling:${var.iam_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
+        "Resource": "arn:${var.arn_region}:autoscaling:${var.aws_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
         "Effect": "Allow"
       }
 

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -121,7 +121,7 @@ resource "aws_iam_role_policy" "worker" {
       {
         "Action": [
            "autoscaling:SetDesiredCapacity",
-           "autoscaling:TerminateInstanceInAutoScalingGroup",
+           "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
         "Resource": "arn:${var.arn_region}:autoscaling:${var.iam_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
         "Effect": "Allow"

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -113,13 +113,20 @@ resource "aws_iam_role_policy" "worker" {
            "autoscaling:DescribeAutoScalingInstances",
            "autoscaling:DescribeLaunchConfigurations",
            "autoscaling:DescribeTags",
-           "autoscaling:SetDesiredCapacity",
-           "autoscaling:TerminateInstanceInAutoScalingGroup",
            "ec2:DescribeLaunchTemplateVersions"
         ],
         "Resource": "*",
         "Effect": "Allow"
+      },
+      {
+        "Action": [
+           "autoscaling:SetDesiredCapacity",
+           "autoscaling:TerminateInstanceInAutoScalingGroup",
+        ],
+        "Resource": "arn:${var.arn_region}:autoscaling:${var.iam_region}:${var.aws_account}:autoScalingGroup:*:autoScalingGroupName/${var.cluster_name}-worker-*",
+        "Effect": "Allow"
       }
+
   ]
 }
 EOF

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -161,7 +161,6 @@ module "bastion" {
 
   arn_region             = var.arn_region
   aws_account            = var.aws_account
-  aws_region             = var.aws_region
   bastion_count          = "2"
   bastion_subnet_ids     = module.vpc.bastion_subnet_ids
   cluster_name           = var.cluster_name
@@ -258,6 +257,7 @@ module "master" {
   api_dns                      = var.api_dns
   api_internal_dns             = var.api_internal_dns
   aws_account                  = var.aws_account
+  aws_region                   = var.aws_region
   aws_cni_cidr_block           = var.aws_cni_cidr_v2
   cluster_name                 = var.cluster_name
   container_linux_ami_id       = data.aws_ami.flatcar_ami[0].image_id

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -161,6 +161,7 @@ module "bastion" {
 
   arn_region             = var.arn_region
   aws_account            = var.aws_account
+  aws_region             = var.aws_region
   bastion_count          = "2"
   bastion_subnet_ids     = module.vpc.bastion_subnet_ids
   cluster_name           = var.cluster_name


### PR DESCRIPTION
Limit node role to restrict access to the CP worker asg only