### PR TITLE
Allow node-exporter metrics on bastion from pod cidr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `first_boot` file in bastion/master/worker ignition templates.
 
+### Changed
+
+- Allow access to bastion node-exporter metrics from pod CIDR.
+
 ## [3.3.0] - 2021-01-22
 
 ### Added

--- a/modules/aws/bastion/bastion.tf
+++ b/modules/aws/bastion/bastion.tf
@@ -69,6 +69,14 @@ resource "aws_security_group" "bastion" {
     cidr_blocks = [var.vpc_cidr]
   }
 
+  # Allow access to node-exporter metrics from pod CIDR
+  ingress {
+    from_port   = 10300
+    to_port     = 10300
+    protocol    = "tcp"
+    cidr_blocks = var.aws_cni_subnets
+  }
+
   # Allow SSH from everywhere
   ingress {
     from_port   = 22

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -6,6 +6,12 @@ variable "aws_account" {
   type = string
 }
 
+
+variable "aws_cni_subnets" {
+  type        = list
+  description = "CIDR for AWS CNI networks used for pods."
+}
+
 variable "bastion_count" {
   type = string
 }

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -161,7 +161,7 @@ module "bastion" {
 
   arn_region             = var.arn_region
   aws_account            = var.aws_account
-  aws_cni_subnets     = var.aws_cni_subnets_v2
+  aws_cni_subnets        = var.aws_cni_subnets_v2
   bastion_count          = "2"
   bastion_subnet_ids     = module.vpc.bastion_subnet_ids
   cluster_name           = var.cluster_name

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -161,6 +161,7 @@ module "bastion" {
 
   arn_region             = var.arn_region
   aws_account            = var.aws_account
+  aws_cni_subnets     = var.aws_cni_subnets_v2
   bastion_count          = "2"
   bastion_subnet_ids     = module.vpc.bastion_subnet_ids
   cluster_name           = var.cluster_name


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15441