### PR TITLE
Add DynamicAuditing feature gate and audit config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable DynamicAuditing feature gate.
+
 ## [3.3.1] - 2021-02-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expand audit logging.
 - Enable DynamicAuditing feature gate.
 
 ## [3.3.1] - 2021-02-02

--- a/templates/files/config/audit-policy.yaml
+++ b/templates/files/config/audit-policy.yaml
@@ -2,6 +2,76 @@ apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
   # TODO: Filter safe system requests.
+    # Log pod changes at RequestResponse level
+  - level: RequestResponse
+    resources:
+    - group: ""
+      # Resource "pods" doesn't match requests to any subresource of pods,
+      # which is consistent with the RBAC policy.
+      resources: ["pods", "deployments"]
+
+  - level: RequestResponse
+    resources:
+    - group: "rbac.authorization.k8s.io"
+      # Resource "pods" doesn't match requests to any subresource of pods,
+      # which is consistent with the RBAC policy.
+      resources: ["clusterroles", "clusterrolebindings"]
+
+  # Log "pods/log", "pods/status" at Metadata level
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+
+  # Don't log requests to a configmap called "controller-leader"
+  - level: None
+    resources:
+    - group: ""
+      resources: ["configmaps"]
+      resourceNames: ["controller-leader"]
+
+  # Don't log watch requests by the "system:kube-proxy" on endpoints or services
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+    - group: "" # core API group
+      resources: ["endpoints", "services"]
+
+  # Don't log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated"]
+    nonResourceURLs:
+    - "/api*" # Wildcard matching.
+    - "/version"
+
+  # Log the request body of configmap changes in kube-system.
+  - level: Request
+    resources:
+    - group: "" # core API group
+      resources: ["configmaps"]
+    # This rule only applies to resources in the "kube-system" namespace.
+    # The empty string "" can be used to select non-namespaced resources.
+    namespaces: ["kube-system"]
+
+  # Log configmap changes in all other namespaces at the RequestResponse level.
+  - level: RequestResponse
+    resources:
+    - group: "" # core API group
+      resources: ["configmaps"]
+
+  # Log secret changes in all other namespaces at the Metadata level.
+  - level: Metadata
+    resources:
+    - group: "" # core API group
+      resources: ["secrets"]
+
+  # Log all other resources in core and extensions at the Request level.
+  - level: Request
+    resources:
+    - group: "" # core API group
+    - group: "extensions" # Version of group should NOT be included.
+    
   # A catch-all rule to log all requests at the Metadata level.
   - level: Metadata
     # Long-running requests like watches that fall under this rule will not

--- a/templates/files/manifests/api-server.yaml
+++ b/templates/files/manifests/api-server.yaml
@@ -53,7 +53,9 @@ spec:
       - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
       - --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
       - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
-      - --feature-gates=TTLAfterFinished=true
+      - --audit-dynamic-configuration
+      - --runtime-config=auditregistration.k8s.io/v1alpha1=true
+      - --feature-gates=TTLAfterFinished=true,DynamicAuditing=true
       - --audit-log-path=/var/log/apiserver/audit.log
       - --audit-log-maxage=30
       - --audit-log-maxbackup=30


### PR DESCRIPTION
Enables auditing for use during the sysdig evaluation.

DynamicAuditing is deprecated as of k8s 1.19, so this will need to be reverted eventually. Sysdig will provide an alternative mechanism.

Additional discussion on Slack https://gigantic.slack.com/archives/C3S482Z98/p1612459837031600