### PR TITLE
Azure Managed Identity optional support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional support for AzureManagedIdentity for Azure VMs.
+
 ## [3.3.1] - 2021-02-02
 
 ### Added

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -55,11 +55,13 @@ variable "azure_sp_subscriptionid" {
 variable "azure_sp_aadclientid" {
   type        = string
   description = "ID of Service Principal for Kubernetes"
+  default     = ""
 }
 
 variable "azure_sp_aadclientsecret" {
   type        = string
   description = "Secret of Service Principal for Kubernetes"
+  default     = ""
 }
 
 variable "master_count" {

--- a/templates/files/conf/azure-master.yaml
+++ b/templates/files/conf/azure-master.yaml
@@ -1,8 +1,12 @@
 cloud: {{ .AzureCloud }}
 tenantId: {{ .AzureSPTenantID }}
 subscriptionId: {{ .AzureSPSubscriptionID }}
+{{ if or (eq .AzureSPAADClientID "") (eq .AzureSPAADClientSecret "") }}
+useManagedIdentityExtension: true
+{{ else }}
 aadClientId: {{ .AzureSPAADClientID }}
 aadClientSecret: {{ .AzureSPAADClientSecret }}
+{{ end }}
 resourceGroup: {{ .AzureResourceGroup }}
 location: {{ .AzureLocation }}
 subnetName: {{ .AzureSubnetName }}

--- a/templates/files/conf/azure-worker.yaml
+++ b/templates/files/conf/azure-worker.yaml
@@ -1,8 +1,12 @@
 cloud: {{ .AzureCloud }}
 tenantId: {{ .AzureSPTenantID }}
 subscriptionId: {{ .AzureSPSubscriptionID }}
+{{ if or (eq .AzureSPAADClientID "") (eq .AzureSPAADClientSecret "") }}
+useManagedIdentityExtension: true
+{{ else }}
 aadClientId: {{ .AzureSPAADClientID }}
 aadClientSecret: {{ .AzureSPAADClientSecret }}
+{{ end }}
 resourceGroup: {{ .AzureResourceGroup }}
 location: {{ .AzureLocation }}
 subnetName: {{ .AzureSubnetName }}


### PR DESCRIPTION
This PR adds support to use azure managed identity to allow kubernetes components to login to azure APIs instead of a service principal.
If either the client ID or the client Secret of the service principal are not set, it will use the managed identity.

Please note this is a PR towards the 3.3 release branch