### PR TITLE
Create bastions in VMware installations

### DIFF
--- a/examples/vmware/bootstrap.sh
+++ b/examples/vmware/bootstrap.sh
@@ -75,6 +75,9 @@ export TF_VAR_nsxt_transport_zone=""
 # CIDR for bastion subnet
 export TF_VAR_bastion_subnet_cidr=""
 
+# Number of bastions to provision (defaults to 1)
+export TF_VAR_bastion_host_count=""
+
 # vSphere configuration
 
 export TF_VAR_vsphere_server=""

--- a/examples/vmware/bootstrap.sh
+++ b/examples/vmware/bootstrap.sh
@@ -72,6 +72,9 @@ export TF_VAR_nsxt_tier0_gateway=""
 export TF_VAR_nsxt_tier1_gateway=""
 export TF_VAR_nsxt_transport_zone=""
 
+# CIDR for bastion subnet
+export TF_VAR_bastion_subnet_cidr=""
+
 # vSphere configuration
 
 export TF_VAR_vsphere_server=""

--- a/modules/vmware/bastion/data.tf
+++ b/modules/vmware/bastion/data.tf
@@ -1,0 +1,23 @@
+data "vsphere_datacenter" "main" {
+  name = var.datacenter
+}
+
+data "vsphere_datastore" "main" {
+  name          = var.datastore
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_compute_cluster" "main" {
+  name          = var.compute_cluster
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_network" "bastion" {
+  name          = var.network
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+data "vsphere_virtual_machine" "main_template" {
+  name          = var.template
+  datacenter_id = data.vsphere_datacenter.main.id
+}

--- a/modules/vmware/bastion/main.tf
+++ b/modules/vmware/bastion/main.tf
@@ -1,0 +1,67 @@
+resource "vsphere_folder" "main" {
+  path          = var.folder
+  type          = "vm"
+  datacenter_id = data.vsphere_datacenter.main.id
+}
+
+resource "vsphere_tag_category" "category" {
+  count = length(var.tags)
+
+  name        = var.tags[count.index]["scope"]
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "VirtualMachine",
+    "Folder"
+  ]
+}
+
+resource "vsphere_tag" "tag" {
+  count = length(var.tags)
+
+  name        = var.tags[count.index]["tag"]
+  category_id = vsphere_tag_category.category[count.index].id
+}
+
+resource "vsphere_virtual_machine" "main" {
+  count = var.node_count
+
+  name             = format("%s-bastion-%s", var.cluster_name, count.index)
+  resource_pool_id = data.vsphere_compute_cluster.main.resource_pool_id
+  datastore_id     = data.vsphere_datastore.main.id
+  folder           = var.folder
+
+  num_cpus = var.cpus_count
+  memory   = var.memory
+  guest_id = data.vsphere_virtual_machine.main_template.guest_id
+
+  network_interface {
+    network_id = data.vsphere_network.bastion.id
+  }
+
+  disk {
+    // It's recommended that you set the disk label to a format matching diskN,
+    // where N is the number of the adisk, starting from disk number 0.
+    // This will ensure that your configuration is compatible when importing a
+    // virtual machine.
+    //
+    // For more information, see the section on importing.
+    label = "disk0"
+    size  = var.root_disk_size
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.main_template.id
+  }
+
+  extra_config = {
+    "guestinfo.ignition.config.data.encoding" = "base64"
+    "guestinfo.ignition.config.data"          = base64encode(var.ignition_data)
+  }
+
+  depends_on = [
+    vsphere_folder.main
+  ]
+
+  tags = vsphere_tag.tag.*.id
+}

--- a/modules/vmware/bastion/variables.tf
+++ b/modules/vmware/bastion/variables.tf
@@ -1,0 +1,74 @@
+# Required variables.
+variable "datacenter" {
+  type        = string
+  description = "The name (ID) of the VMware datacenter. This can be a name or path."
+}
+
+variable "datastore" {
+  type        = string
+  description = "The name (ID) of the VMware datastore. This can be a name or path."
+}
+
+variable "compute_cluster" {
+  type        = string
+  description = "The name (ID) of the VMware computer cluster used for the placement of the virtual machine."
+}
+
+variable "network" {
+  type        = string
+  description = "The name (ID) of the VMware network to connect the main interface to. This can be a name or path."
+}
+
+variable "template" {
+  type        = string
+  description = "The name (ID) of the VMware template used for the creation of the instance."
+}
+
+variable "folder" {
+  type        = string
+  description = "The path to the folder to put this virtual machine in, relative to the datacenter that the resource pool is in."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster identifier which will be used in controller node names."
+}
+
+variable "ignition_data" {
+  type        = string
+  description = "Ignition config template (non-base64)."
+}
+
+# Optional variables.
+variable "node_count" {
+  type        = number
+  description = "Number of nodes to create."
+  default     = 1
+}
+
+variable "cpus_count" {
+  type        = number
+  description = "The total number of virtual processor cores to assign to this virtual machine."
+  default     = 2
+}
+
+variable "memory" {
+  type        = number
+  description = "The size of the virtual machine's memory, in MB."
+  default     = 2048
+}
+
+variable "root_disk_size" {
+  type        = number
+  description = "The root size of the virtual machine's disk, in GB."
+  default     = 30
+}
+
+variable "tags" {
+  type = list(object({
+    scope = string
+    tag   = string
+  }))
+
+  default = []
+}

--- a/modules/vmware/bastion/versions.tf
+++ b/modules/vmware/bastion/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "1.24.3"
+    }
+  }
+}

--- a/modules/vmware/nsx-t/data.tf
+++ b/modules/vmware/nsx-t/data.tf
@@ -20,3 +20,8 @@ data "nsxt_policy_realization_info" "segment_info" {
   path = nsxt_policy_segment.vmnet1.path
   entity_type = "RealizedLogicalSwitch"
 }
+
+data "nsxt_policy_realization_info" "bastion_segment_info" {
+  path = nsxt_policy_segment.bastion-vmnet.path
+  entity_type = "RealizedLogicalSwitch"
+}

--- a/modules/vmware/nsx-t/dhcp.tf
+++ b/modules/vmware/nsx-t/dhcp.tf
@@ -9,7 +9,7 @@ resource "nsxt_logical_dhcp_server" "dhcp_server" {
 
   // reproduce tre behaviour of AWS setting the DHCP Server IP + 2 IP
   // i.e. CIDR: 10.100.0.0/8 - DHCP Server IP: 10.100.0.2
-  dhcp_server_ip    = "${cidrhost(var.management_cluster_cidr, 2)}/${local.subnet_mask}"
+  dhcp_server_ip    = "${cidrhost(var.management_cluster_cidr, 2)}/${local.mc_subnet_mask}"
   gateway_ip        = cidrhost(var.management_cluster_cidr, 1)
   dns_name_servers  = var.dns_addresses
 

--- a/modules/vmware/nsx-t/dhcp_bastion.tf
+++ b/modules/vmware/nsx-t/dhcp_bastion.tf
@@ -46,8 +46,8 @@ resource "nsxt_dhcp_server_ip_pool" "dhcp_bastion_ip_pool" {
 
   ip_range {
     // start from local value (usually .5) and only allocate enough IPs for the requested number of bastions
-    start = cidrhost(var.management_cluster_cidr, local.bastion_dhcp_pool_start)
-    end   = cidrhost(var.management_cluster_cidr, local.bastion_dhcp_pool_end)
+    start = cidrhost(var.bastion_subnet_cidr, local.bastion_dhcp_pool_start)
+    end   = cidrhost(var.bastion_subnet_cidr, local.bastion_dhcp_pool_end)
   }
 
   dynamic "tag" {

--- a/modules/vmware/nsx-t/dhcp_bastion.tf
+++ b/modules/vmware/nsx-t/dhcp_bastion.tf
@@ -1,0 +1,61 @@
+resource "nsxt_logical_dhcp_server" "dhcp_server_bastion" {
+  display_name = format("dhcp-server-%s-bastion", var.cluster_name)
+
+  dhcp_profile_id = nsxt_dhcp_server_profile.server_profile.id
+
+  // reproduce the behaviour of AWS DHCP Server IP + 2 IP
+  // i.e. CIDR: 10.100.0.0/8 - DHCP Server IP: 10.100.0.2
+  dhcp_server_ip   = "${cidrhost(var.bastion_subnet_cidr, 2)}/${local.bastion_subnet_mask}"
+  gateway_ip       = cidrhost(var.bastion_subnet_cidr, 1)
+  dns_name_servers = var.dns_addresses
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      scope = tag.value["scope"]
+      tag   = tag.value["tag"]
+    }
+  }
+}
+
+resource "nsxt_logical_dhcp_port" "dhcp_port_bastion" {
+  admin_state  = "UP"
+  display_name = format("%s-%s-lp", nsxt_policy_segment.bastion-vmnet.display_name, nsxt_logical_dhcp_server.dhcp_server_bastion.display_name)
+
+  logical_switch_id = data.nsxt_policy_realization_info.bastion_segment_info.realized_id
+  dhcp_server_id    = nsxt_logical_dhcp_server.dhcp_server_bastion.id
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      scope = tag.value["scope"]
+      tag   = tag.value["tag"]
+    }
+  }
+}
+
+resource "nsxt_dhcp_server_ip_pool" "dhcp_bastion_ip_pool" {
+  display_name           = format("ip-pool-%s-%s", nsxt_policy_segment.bastion-vmnet.display_name, cidrhost(var.bastion_subnet_cidr, 0))
+  logical_dhcp_server_id = nsxt_logical_dhcp_server.dhcp_server_bastion.id
+  gateway_ip             = cidrhost(var.bastion_subnet_cidr, 1)
+  lease_time             = 2592000
+  error_threshold        = 98
+  warning_threshold      = 70
+
+  ip_range {
+    // start from local value (usually .5) and only allocate enough IPs for the requested number of bastions
+    start = cidrhost(var.management_cluster_cidr, local.bastion_dhcp_pool_start)
+    end   = cidrhost(var.management_cluster_cidr, local.bastion_dhcp_pool_end)
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      scope = tag.value["scope"]
+      tag   = tag.value["tag"]
+    }
+  }
+}

--- a/modules/vmware/nsx-t/locals.tf
+++ b/modules/vmware/nsx-t/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  subnet_mask = split("/", var.management_cluster_cidr)[1]
-  max_hosts   = pow(2, local.subnet_mask) - 2
+  bastion_subnet_mask = split("/", var.bastion_subnet_cidr)[1]
+  subnet_mask         = split("/", var.management_cluster_cidr)[1]
+  max_hosts           = pow(2, local.subnet_mask) - 2
 }

--- a/modules/vmware/nsx-t/locals.tf
+++ b/modules/vmware/nsx-t/locals.tf
@@ -1,5 +1,9 @@
 locals {
-  bastion_subnet_mask = split("/", var.bastion_subnet_cidr)[1]
-  mc_subnet_mask      = split("/", var.management_cluster_cidr)[1]
-  max_hosts           = pow(2, local.mc_subnet_mask) - 2
+  mc_subnet_mask = split("/", var.management_cluster_cidr)[1]
+  max_hosts      = pow(2, local.mc_subnet_mask) - 2
+
+  bastion_subnet_mask     = split("/", var.bastion_subnet_cidr)[1]
+  bastion_dhcp_pool_start = 5
+  bastion_dhcp_pool_end   = local.bastion_dhcp_pool_start + local.bastion_host_count
+  bastion_host_count      = var.bastion_host_count
 }

--- a/modules/vmware/nsx-t/locals.tf
+++ b/modules/vmware/nsx-t/locals.tf
@@ -1,5 +1,5 @@
 locals {
   bastion_subnet_mask = split("/", var.bastion_subnet_cidr)[1]
-  subnet_mask         = split("/", var.management_cluster_cidr)[1]
-  max_hosts           = pow(2, local.subnet_mask) - 2
+  mc_subnet_mask      = split("/", var.management_cluster_cidr)[1]
+  max_hosts           = pow(2, local.mc_subnet_mask) - 2
 }

--- a/modules/vmware/nsx-t/outputs.tf
+++ b/modules/vmware/nsx-t/outputs.tf
@@ -1,3 +1,7 @@
 output "vm_network" {
   value = nsxt_policy_segment.vmnet1.display_name
 }
+
+output "bastion_network" {
+  value = nsxt_policy_segment.bastion-vmnet.display_name
+}

--- a/modules/vmware/nsx-t/segments.tf
+++ b/modules/vmware/nsx-t/segments.tf
@@ -18,3 +18,24 @@ resource "nsxt_policy_segment" "vmnet1" {
     }
   }
 }
+
+resource "nsxt_policy_segment" "bastion-vmnet" {
+  display_name        = format("%s-bastion-vmnet", var.cluster_name)
+  connectivity_path   = var.tier1_gateway != "" ? data.nsxt_policy_tier1_gateway.tier1_gw_gateway[0].path : nsxt_policy_tier1_gateway.tier1_gw[0].path
+  transport_zone_path = data.nsxt_policy_transport_zone.overlay.path
+
+  nsx_id = format("%s-bastion-vmnet", var.cluster_name)
+
+  subnet {
+    cidr = "${cidrhost(var.bastion_subnet_cidr, 1)}/${local.bastion_subnet_mask}"
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      scope = tag.value["scope"]
+      tag   = tag.value["tag"]
+    }
+  }
+}

--- a/modules/vmware/nsx-t/segments.tf
+++ b/modules/vmware/nsx-t/segments.tf
@@ -6,7 +6,7 @@ resource "nsxt_policy_segment" "vmnet1" {
   nsx_id = format("%s-vmnet1", var.cluster_name)
 
   subnet {
-    cidr = "${cidrhost(var.management_cluster_cidr, 1)}/${local.subnet_mask}"
+    cidr = "${cidrhost(var.management_cluster_cidr, 1)}/${local.mc_subnet_mask}"
   }
 
   dynamic "tag" {

--- a/modules/vmware/nsx-t/variables.tf
+++ b/modules/vmware/nsx-t/variables.tf
@@ -51,6 +51,11 @@ variable "tags" {
 
 # bastion variables
 
+variable "bastion_host_count" {
+  type        = number
+  description = "Number of bastions to provision"
+}
+
 variable "bastion_subnet_cidr" {
   type        = string
   description = "CIDR block to use for the bastion subnet"

--- a/modules/vmware/nsx-t/variables.tf
+++ b/modules/vmware/nsx-t/variables.tf
@@ -48,3 +48,10 @@ variable "tags" {
 
   default = []
 }
+
+# bastion variables
+
+variable "bastion_subnet_cidr" {
+  type        = string
+  description = "CIDR block to use for the bastion subnet"
+}

--- a/platforms/vmware/giantnetes/main.tf
+++ b/platforms/vmware/giantnetes/main.tf
@@ -32,6 +32,7 @@ module "nsxt" {
   public_ip_address = var.public_ip_address
   dns_addresses     = var.dns_addresses
 
+  bastion_host_count  = var.bastion_host_count
   bastion_subnet_cidr = var.bastion_subnet_cidr
 
   tags = local.tags

--- a/platforms/vmware/giantnetes/main.tf
+++ b/platforms/vmware/giantnetes/main.tf
@@ -4,6 +4,9 @@ terraform {
 
 locals {
   tags = concat([{ scope = "Managed By Terraform", tag = "true" }], var.tags)
+  ignition_data = {
+    "Provider" = "vmware"
+  }
 }
 
 provider "nsxt" {
@@ -73,6 +76,59 @@ module "vault" {
   logs_disk_size = var.vault_logs_disk_size
 
   ignition_data = ""
+
+  tags = local.tags
+
+  depends_on = [module.nsxt]
+}
+
+module "flatcar_linux" {
+  source = "../../../modules/flatcar-linux"
+
+  flatcar_channel = var.flatcar_linux_channel
+  flatcar_version = var.flatcar_linux_version
+}
+
+data "http" "bastion_users" {
+  url = "https://api.github.com/repos/giantswarm/employees/contents/employees.yaml?ref=${var.employees_branch}"
+
+  request_headers = {
+    Authorization = "token ${var.github_token}"
+  }
+}
+
+# bastion ignition config
+data "gotemplate" "bastion" {
+  template    = "${path.module}/../../../templates/bastion.yaml.tmpl"
+  data        = jsonencode(merge(local.ignition_data, { "NodeType" = "bastion" }))
+  is_ignition = true
+}
+
+module "bastion" {
+  source = "../../../modules/vmware/bastion"
+
+  count = var.bastion_enabled ? 1 : 0
+
+  cluster_name = var.cluster_name
+
+  // VMware variables
+  datacenter      = var.vsphere_datacenter
+  datastore       = var.vsphere_datastore
+  compute_cluster = var.vsphere_compute_cluster
+
+  // In the case we do not use NSX-T the network where to attach VMs
+  // must be already created and passed as input variable
+  //
+  network  = var.nsxt_enabled ? module.nsxt[0].bastion_network : var.vsphere_network
+  template = var.vsphere_template
+  folder   = var.vsphere_folder
+
+  node_count       = var.bastion_node_count
+  cpus_count       = var.bastion_cpus_count
+  memory           = var.bastion_memory
+  root_disk_size   = var.bastion_root_disk_size
+
+  ignition_data = data.gotemplate.bastion.rendered
 
   tags = local.tags
 

--- a/platforms/vmware/giantnetes/main.tf
+++ b/platforms/vmware/giantnetes/main.tf
@@ -5,7 +5,9 @@ terraform {
 locals {
   tags = concat([{ scope = "Managed By Terraform", tag = "true" }], var.tags)
   ignition_data = {
-    "Provider" = "vmware"
+    "DockerCIDR" = var.docker_cidr
+    "Provider"   = "vmware"
+    "Users"      = yamldecode(base64decode(jsondecode(data.http.bastion_users.body).content))
   }
 }
 

--- a/platforms/vmware/giantnetes/main.tf
+++ b/platforms/vmware/giantnetes/main.tf
@@ -32,6 +32,8 @@ module "nsxt" {
   public_ip_address = var.public_ip_address
   dns_addresses     = var.dns_addresses
 
+  bastion_subnet_cidr = var.bastion_subnet_cidr
+
   tags = local.tags
 }
 

--- a/platforms/vmware/giantnetes/main.tf
+++ b/platforms/vmware/giantnetes/main.tf
@@ -84,13 +84,6 @@ module "vault" {
   depends_on = [module.nsxt]
 }
 
-module "flatcar_linux" {
-  source = "../../../modules/flatcar-linux"
-
-  flatcar_channel = var.flatcar_linux_channel
-  flatcar_version = var.flatcar_linux_version
-}
-
 data "http" "bastion_users" {
   url = "https://api.github.com/repos/giantswarm/employees/contents/employees.yaml?ref=${var.employees_branch}"
 

--- a/platforms/vmware/giantnetes/variables.tf
+++ b/platforms/vmware/giantnetes/variables.tf
@@ -107,6 +107,17 @@ variable "bastion_subnet_cidr" {
   default     = ""
 }
 
+variable "github_token" {
+  type        = string
+  description = "Your personal Github token, used to get access to github.com/giantswarm/employees to get the list of users."
+}
+
+variable "employees_branch" {
+  type        = string
+  description = "The branch in giantswarm/employees repo to use for getting a list of users"
+  default     = "master"
+}
+
 # Root DNS zone variables
 
 variable "dns_use_route53" {
@@ -162,6 +173,50 @@ variable "vsphere_template" {
 variable "vsphere_folder" {
   type        = string
   description = "The path to the folder to put this virtual machine in, relative to the datacenter that the resource pool is in."
+}
+
+# Flatcar variables
+
+variable "flatcar_linux_channel" {
+  description = "Flatcar linux channel (e.g. stable, beta, alpha)."
+  default     = "stable"
+}
+
+variable "flatcar_linux_version" {
+  description = "Flatcar linux version."
+  type        = string
+  default     = "2765.2.2"
+}
+
+# bastion variables
+
+variable "bastion_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "bastion_node_count" {
+  type        = number
+  description = "Number of bastions to create."
+  default     = 1
+}
+
+variable "bastion_cpus_count" {
+  type        = number
+  description = "The total number of virtual processor cores to assign to this virtual machine."
+  default     = 2
+}
+
+variable "bastion_memory" {
+  type        = number
+  description = "The size of the virtual machine's memory, in MB."
+  default     = 2048
+}
+
+variable "bastion_root_disk_size" {
+  type        = number
+  description = "The root size of the virtual machine's disk, in GB."
+  default     = 30
 }
 
 # Optional variables.

--- a/platforms/vmware/giantnetes/variables.tf
+++ b/platforms/vmware/giantnetes/variables.tf
@@ -93,6 +93,14 @@ variable "dns_addresses" {
   ]
 }
 
+# Bastion variables
+
+variable "bastion_subnet_cidr" {
+  type        = string
+  description = "CIDR block to use for the bastion subnet"
+  default     = ""
+}
+
 # Root DNS zone variables
 
 variable "dns_use_route53" {

--- a/platforms/vmware/giantnetes/variables.tf
+++ b/platforms/vmware/giantnetes/variables.tf
@@ -95,6 +95,12 @@ variable "dns_addresses" {
 
 # Bastion variables
 
+variable "bastion_host_count" {
+  type        = number
+  description = "Number of bastions to provision"
+  default     = 1
+}
+
 variable "bastion_subnet_cidr" {
   type        = string
   description = "CIDR block to use for the bastion subnet"

--- a/platforms/vmware/giantnetes/variables.tf
+++ b/platforms/vmware/giantnetes/variables.tf
@@ -16,6 +16,12 @@ variable "base_domain" {
   description = "Base domain for g8s cluster (e.g $CLUSTER_NAME.$PROVIDER.vmware.gigantic.io)."
 }
 
+variable "docker_cidr" {
+  type        = string
+  description = "CIDR for Docker."
+  default     = "172.17.0.1/16"
+}
+
 # Route53 DNS variables
 
 variable "root_dns_zone_id" {

--- a/platforms/vmware/giantnetes/variables.tf
+++ b/platforms/vmware/giantnetes/variables.tf
@@ -181,19 +181,6 @@ variable "vsphere_folder" {
   description = "The path to the folder to put this virtual machine in, relative to the datacenter that the resource pool is in."
 }
 
-# Flatcar variables
-
-variable "flatcar_linux_channel" {
-  description = "Flatcar linux channel (e.g. stable, beta, alpha)."
-  default     = "stable"
-}
-
-variable "flatcar_linux_version" {
-  description = "Flatcar linux version."
-  type        = string
-  default     = "2765.2.2"
-}
-
 # bastion variables
 
 variable "bastion_enabled" {

--- a/platforms/vmware/giantnetes/versions.tf
+++ b/platforms/vmware/giantnetes/versions.tf
@@ -2,6 +2,12 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
+    gotemplate = {
+      source = "giantswarm.io/operations/gotemplate"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
     nsxt = {
       source  = "vmware/nsxt"
       version = "3.1.1"


### PR DESCRIPTION
This PR:
- adds support for a single bastion for an installation. the bastion resides in its own subnet which is attached to the same tier 1 router as the MC subnet so can access MC nodes.
