### PR TITLE
aws-increase-root-disk

### DIFF
--- a/modules/aws/master/variables.tf
+++ b/modules/aws/master/variables.tf
@@ -104,7 +104,7 @@ variable "volume_size_etcd" {
 
 variable "volume_size_root" {
   type    = string
-  default = 8
+  default = 30
 }
 
 variable "volume_docker" {

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -79,7 +79,7 @@ variable "volume_size_etcd" {
 
 variable "volume_size_root" {
   type    = string
-  default = 8
+  default = 30
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/16188

8GB disk has causes warning that we get `Warning: EBS Volumes are out of burst balance`, increasing the disk a little bit should give us better performance, its not critical or urgent but can improve overall speed of AWS CP

the cost increase should be low (around 10$ per month for whole CP)