### PR TITLE
remove-aws-cni-v1

### DIFF
--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -11,17 +11,6 @@ variable "az_count" {
   default = "2"
 }
 
-# leaving here for now for migrationg part
-# it will be removed in second step
-variable "aws_cni_cidr_block" {
-  type = string
-}
-
-variable "aws_cni_pod_cidrs" {
-  type = list
-}
-
-# using v2 due the need to migrate to bigger subnets
 variable "aws_cni_cidr_v2" {
   type = string
 }

--- a/modules/aws/vpc/vpc-subnet-cni.tf
+++ b/modules/aws/vpc/vpc-subnet-cni.tf
@@ -1,24 +1,3 @@
-resource "aws_vpc_ipv4_cidr_block_association" "cni" {
-  vpc_id     = aws_vpc.cluster_vpc.id
-  cidr_block = var.aws_cni_cidr_block
-}
-
-resource "aws_subnet" "cni" {
-  count = length(var.aws_cni_pod_cidrs)
-
-  vpc_id            = aws_vpc.cluster_vpc.id
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = var.aws_cni_pod_cidrs[count.index]
-
-  tags = merge(
-    local.common_tags,
-    map(
-      "Name", "${var.cluster_name}-cni${count.index}"
-    )
-  )
-  depends_on = [aws_vpc_ipv4_cidr_block_association.cni]
-}
-
 resource "aws_vpc_ipv4_cidr_block_association" "cni_v2" {
   vpc_id     = aws_vpc.cluster_vpc.id
   cidr_block = var.aws_cni_cidr_v2

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -72,8 +72,6 @@ module "vpc" {
 
   arn_region         = var.arn_region
   aws_account        = var.aws_account
-  aws_cni_cidr_block = var.aws_cni_cidr_block
-  aws_cni_pod_cidrs  = var.aws_cni_pod_cidrs
   aws_cni_cidr_v2    = var.aws_cni_cidr_v2
   aws_cni_subnets_v2 = var.aws_cni_subnets_v2
   cluster_name       = var.cluster_name

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -191,20 +191,6 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
-# leaving here for now for migrationg part
-# it will be removed in second step
-variable "aws_cni_cidr_block" {
-  description = "Whole CIDR block for AWS CNI."
-  default     = "10.100.0.0/20"
-}
-
-variable "aws_cni_pod_cidrs" {
-  type        = list(any)
-  description = "CIDR for AWS CNI networks used for pods."
-  default     = ["10.100.0.0/24", "10.100.1.0/24", "10.100.2.0/24"]
-}
-
-# using v2 due the need to migrate to bigger subnets
 variable "aws_cni_cidr_v2" {
   description = "Whole CIDR block for AWS CNI. Using CGNAT range for all CPs."
   default     = "100.64.0.0/16"


### PR DESCRIPTION
remove old unused CNI subnets that were left after migration to v2