### PR TITLE
Add kubelet flag to better detect memory eviction threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `nginx-ingress-controller` to v0.33.0.
+- Set `kernelMemcgNotification` kubelet flag to true. This helps better determine if memory eviction thresholds are crossed.
 
 ## [4.1.0] - 2021-07-27
 

--- a/templates/files/config/kubelet-master.yaml.tmpl
+++ b/templates/files/config/kubelet-master.yaml.tmpl
@@ -11,6 +11,7 @@ clusterDomain: cluster.local
 featureGates:
   ExpandPersistentVolumes: true
 staticPodPath: /etc/kubernetes/manifests
+kernelMemcgNotification: true
 evictionSoft:
   memory.available:  "500Mi"
 evictionHard:

--- a/templates/files/config/kubelet-worker.yaml.tmpl
+++ b/templates/files/config/kubelet-worker.yaml.tmpl
@@ -10,6 +10,7 @@ clusterDNS:
 clusterDomain: cluster.local
 featureGates:
   ExpandPersistentVolumes: true
+kernelMemcgNotification: true
 evictionSoft:
   memory.available:  "500Mi"
 evictionHard:


### PR DESCRIPTION
This change is already pushed to WCs. 

Flag description:
> kernelMemcgNotification, if set, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling. Dynamic Kubelet Config (beta): If dynamically updating this field, consider that it may impact the way Kubelet interacts with the kernel. Default: false

https://v1-20.docs.kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/