### PR TITLE
Change Azure storage account authentication key (SAS) TTL to 180 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove AWS `vpn_instance` module. It was used for China regions and it's
   replaced with the Direct Connect setup.
 
+### Changed
+
+- Change Azure storage account authentication key (SAS) TTL to 180 days to comply with workload clusters.
+
 ## [5.0.0] - 2021-08-25
 
 ## [4.2.0] - 2021-08-24

--- a/modules/azure/master-as/master-ignition.tf
+++ b/modules/azure/master-as/master-ignition.tf
@@ -23,9 +23,9 @@ data "azurerm_storage_account_sas" "sas" {
   connection_string = var.storage_acc_url
   https_only        = true
 
-  # Set TTL to 3 months from execution time.
+  # Set TTL to 6 months from execution time.
   start  = local.timenow
-  expiry = timeadd(local.timenow, "2160h")
+  expiry = timeadd(local.timenow, "4320h")
 
   resource_types {
     service   = false


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19843

180 days is what we have in workload clusters