### PR TITLE
aws-add-additional-tags-variable

### DIFF
--- a/modules/aws/bastion/bastion-logs.tf
+++ b/modules/aws/bastion/bastion-logs.tf
@@ -2,10 +2,7 @@ resource "aws_cloudwatch_log_group" "bastion_log_group" {
   count = var.forward_logs_enabled ? 1 : 0
   name  = "${var.cluster_name}_bastion"
 
-  tags = {
-    "giantswarm.io/cluster"      = var.cluster_name
-    "giantswarm.io/installation" = var.cluster_name
-  }
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_log_stream" "bastion_logs" {

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -88,3 +88,10 @@ variable "transit_vpc_cidr" {
   type        = string
 }
 
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}
+}
+

--- a/modules/aws/master/variables.tf
+++ b/modules/aws/master/variables.tf
@@ -124,3 +124,10 @@ variable "vpc_id" {
 }
 
 variable "s3_bucket_tags" {}
+
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -1,8 +1,12 @@
 locals {
-  common_tags = map(
-    "giantswarm.io/cluster", var.cluster_name,
-    "giantswarm.io/installation", var.cluster_name,
-    "kubernetes.io/cluster/${var.cluster_name}", "owned"
+  common_tags = merge(
+    var.additional_tags,
+    map(
+      "giantswarm.io/cluster", var.cluster_name,
+      "giantswarm.io/installation", var.cluster_name,
+      "giantswarm.io/cluster-type", "control-plane",
+      "kubernetes.io/cluster/${var.cluster_name}", "owned"
+    )
   )
 }
 

--- a/modules/aws/s3/variables.tf
+++ b/modules/aws/s3/variables.tf
@@ -13,3 +13,10 @@ variable "logs_expiration_days" {
 variable "s3_bucket_prefix" {
   type = string
 }
+
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}
+}

--- a/modules/aws/vault/variables.tf
+++ b/modules/aws/vault/variables.tf
@@ -106,3 +106,10 @@ variable "worker_subnet_count" {
 }
 
 variable "s3_bucket_tags" {}
+
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}
+}

--- a/modules/aws/vault/vault-elb.tf
+++ b/modules/aws/vault/vault-elb.tf
@@ -19,11 +19,12 @@ resource "aws_elb" "vault" {
     interval            = 5
   }
 
-  tags = {
-    Name                         = "${var.cluster_name}-vault"
-    "giantswarm.io/cluster"      = var.cluster_name
-    "giantswarm.io/installation" = var.cluster_name
-  }
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-vault"
+    )
+  )
 }
 
 resource "aws_elb_attachment" "vault" {
@@ -57,11 +58,12 @@ resource "aws_security_group" "vault_elb" {
     cidr_blocks = [var.ipam_network_cidr]
   }
 
-  tags = {
-    Name                         = "${var.cluster_name}-vault-elb"
-    "giantswarm.io/cluster"      = var.cluster_name
-    "giantswarm.io/installation" = var.cluster_name
-  }
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-vault-elb"
+    )
+  )
 }
 
 resource "aws_route53_record" "vault-elb" {

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -61,3 +61,9 @@ variable "transit_vpc_cidr" {
   type = string
 }
 
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}
+}

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -7,11 +7,14 @@
 #   * the private nat gateway is in the elb subnet as well (needs to be in a public subnet)
 
 locals {
-  common_tags = map(
-    "giantswarm.io/cluster", var.cluster_name,
-    "giantswarm.io/installation", var.cluster_name,
-    "giantswarm.io/cluster-type", "control-plane",
-    "kubernetes.io/cluster/${var.cluster_name}", "owned"
+  common_tags = merge(
+    var.additional_tags,
+    map(
+      "giantswarm.io/cluster", var.cluster_name,
+      "giantswarm.io/installation", var.cluster_name,
+      "giantswarm.io/cluster-type", "control-plane",
+      "kubernetes.io/cluster/${var.cluster_name}", "owned"
+    )
   )
 
   policy_allow = <<EOF

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -91,3 +91,10 @@ variable "vpc_id" {
 }
 
 variable "s3_bucket_tags" {}
+
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}
+}

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -70,6 +70,7 @@ module "dns" {
 module "vpc" {
   source = "../../../modules/aws/vpc"
 
+  additional_tags    = var.additional_tags
   arn_region         = var.arn_region
   aws_account        = var.aws_account
   aws_cni_cidr_v2    = var.aws_cni_cidr_v2
@@ -89,6 +90,7 @@ module "vpc" {
 module "s3" {
   source = "../../../modules/aws/s3"
 
+  additional_tags      = var.additional_tags
   aws_account          = var.aws_account
   cluster_name         = var.cluster_name
   logs_expiration_days = var.logs_expiration_days
@@ -157,6 +159,7 @@ data "gotemplate" "bastion" {
 module "bastion" {
   source = "../../../modules/aws/bastion"
 
+  additional_tags        = var.additional_tags
   arn_region             = var.arn_region
   aws_account            = var.aws_account
   aws_cni_subnets        = var.aws_cni_subnets_v2
@@ -187,6 +190,7 @@ data "gotemplate" "vault" {
 module "vault" {
   source = "../../../modules/aws/vault"
 
+  additional_tags        = var.additional_tags
   arn_region             = var.arn_region
   aws_account            = var.aws_account
   aws_cni_cidr_block     = var.aws_cni_cidr_v2
@@ -224,6 +228,7 @@ module "master" {
 
   master_count = var.master_count
 
+  additional_tags              = var.additional_tags
   api_dns                      = var.api_dns
   api_internal_dns             = var.api_internal_dns
   aws_account                  = var.aws_account
@@ -262,6 +267,7 @@ data "gotemplate" "worker" {
 module "worker" {
   source = "../../../modules/aws/worker-asg"
 
+  additional_tags        = var.additional_tags
   aws_account            = var.aws_account
   aws_region             = var.aws_region
   aws_cni_cidr_block     = var.aws_cni_cidr_v2

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -369,3 +369,10 @@ variable "release_version" {
   type        = string
   default     = ""
 }
+
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}  
+}


### PR DESCRIPTION
towards https://github.com/giantswarm/vodafone/issues/493

add an option to add custom tags to all was resources


tested on ginger, vault is not replaced, most of the resources are only updated in place ( except nodes which are rolled)