### PR TITLE
aws-tag-all-volumes

### DIFF
--- a/modules/aws/bastion/bastion.tf
+++ b/modules/aws/bastion/bastion.tf
@@ -34,6 +34,7 @@ resource "aws_instance" "bastion" {
   root_block_device {
     volume_type = var.volume_type
     volume_size = var.volume_size_root
+    tags = local.common_tags
   }
 
   user_data = data.ignition_config.s3.rendered

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -51,6 +51,11 @@ resource "aws_iam_role_policy" "worker" {
       "Resource": "*"
     },
     {
+     "Effect": "Allow",
+     "Action": "ec2:CreateTags",
+      "Resource": "*"
+    },
+    {
       "Action": "elasticloadbalancing:*",
       "Resource": "*",
       "Effect": "Allow"

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -10,6 +10,8 @@ locals {
   masters_eni_ips         = [cidrhost(var.subnets_worker[0], 4), cidrhost(var.subnets_worker[1], 4), cidrhost(var.subnets_worker[2], 4)]
   masters_eni_gateways    = [cidrhost(var.subnets_worker[0], 1), cidrhost(var.subnets_worker[1], 1), cidrhost(var.subnets_worker[2], 1)]
   masters_eni_subnet_size = split("/", var.subnets_worker[0])[1]
+
+  additional_tags_ignition = join(" ", [for key, value in var.additional_tags : "Key=${key},Value=${value}"])
 }
 
 data "http" "bastion_users" {
@@ -99,6 +101,7 @@ module "s3" {
 
 locals {
   ignition_data = {
+    "AdditionalTags"               = local.additional_tags_ignition
     "AvaiabilityZones"             = data.aws_availability_zones.available.names
     "APIDomainName"                = "${var.api_dns}.${var.base_domain}"
     "APIInternalDomainName"        = "${var.api_internal_dns}.${var.base_domain}"

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -373,6 +373,6 @@ variable "release_version" {
 ### additional tags
 variable "additional_tags" {
   description = "Additional tags that can be added to all resources"
-  type        = map
-  default     = {}  
+  type        = map(string)
+  default     = {}
 }

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1148,8 +1148,8 @@ systemd:
     contents: |
       [Unit]
       Description=Tag all EBS volumes attached to the machine with proper tags
-      After=docker.service etcd3.service
-      Requires=docker.service etcd3.service
+      After=docker.service
+      Requires=docker.service
 
       [Service]
       Type=oneshot

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1159,7 +1159,7 @@ systemd:
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
       ExecStartPre=-/usr/bin/docker pull $IMAGE
-      ExecStart=/usr/bin/docker run -it --network=host --entrypoint /bin/bash $IMAGE -c "export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id -qs); export volume_ids=$(aws ec2 describe-volumes --filter Name=attachment.instance-id,Values=$instance_id --query Volumes[*].VolumeId --out=text) ; aws ec2 create-tags --resources $volume_ids --tags {{.AdditionalTags}}; echo tagged volumes $volume_ids"
+      ExecStart=/usr/bin/docker run --network=host --entrypoint /bin/bash $IMAGE -c "export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id -qs); export volume_ids=$(aws ec2 describe-volumes --filter Name=attachment.instance-id,Values=$instance_id --query Volumes[*].VolumeId --out=text) ; aws ec2 create-tags --resources $volume_ids --tags {{.AdditionalTags}}; echo tagged volumes $volume_ids"
 
       [Install]
       WantedBy=multi-user.target

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1142,6 +1142,39 @@ systemd:
 
       [Install]
       WantedBy=multi-user.target
+{{ if ne .AdditionalTags "" }}
+  - name: tag-ebs-volumes.service
+    enabled: false
+    contents: |
+      [Unit]
+      Description=Tag all EBS volumes attached to the machine with proper tags
+      After=docker.service etcd3.service
+      Requires=docker.service etcd3.service
+
+      [Service]
+      Type=oneshot
+      EnvironmentFile=/etc/environment
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/awscli:2.0.24
+      Environment=NAME=%p.service
+      ExecStartPre=-/usr/bin/docker stop  $NAME
+      ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
+      ExecStart=/usr/bin/docker run -it --network=host --entrypoint /bin/bash $IMAGE -c "export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id -qs); export volume_ids=$(aws ec2 describe-volumes --filter Name=attachment.instance-id,Values=$instance_id --query Volumes[*].VolumeId --out=text) ; aws ec2 create-tags --resources $volume_ids --tags {{.AdditionalTags}}; echo tagged volumes $volume_ids"
+
+      [Install]
+      WantedBy=multi-user.target
+  - name: tag-ebs-volumes.timer
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Execute tag-ebs-volumes.service every hour
+
+      [Timer]
+      OnCalendar=*-*-* *:00:00 UTC
+
+      [Install]
+      WantedBy=multi-user.target
+{{end}}
 {{end}}
   - name: k8s-extract.service
     enabled: true

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -477,7 +477,7 @@ systemd:
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
       ExecStartPre=-/usr/bin/docker pull $IMAGE
-      ExecStart=/usr/bin/docker run -it --network=host --entrypoint /bin/bash $IMAGE -c "export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id -qs); export volume_ids=$(aws ec2 describe-volumes --filter Name=attachment.instance-id,Values=$instance_id --query Volumes[*].VolumeId --out=text) ; aws ec2 create-tags --resources $volume_ids --tags {{.AdditionalTags}}; echo tagged volumes $volume_ids"
+      ExecStart=/usr/bin/docker run  --network=host --entrypoint /bin/bash $IMAGE -c "export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id -qs); export volume_ids=$(aws ec2 describe-volumes --filter Name=attachment.instance-id,Values=$instance_id --query Volumes[*].VolumeId --out=text) ; aws ec2 create-tags --resources $volume_ids --tags {{.AdditionalTags}}; echo tagged volumes $volume_ids"
 
       [Install]
       WantedBy=multi-user.target

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -460,6 +460,39 @@ systemd:
 
       [Install]
       WantedBy=multi-user.target
+{{ if ne .AdditionalTags "" }}
+  - name: tag-ebs-volumes.service
+    enabled: false
+    contents: |
+      [Unit]
+      Description=Tag all EBS volumes attached to the machine with proper tags
+      After=docker.service etcd3.service
+      Requires=docker.service etcd3.service
+
+      [Service]
+      Type=oneshot
+      EnvironmentFile=/etc/environment
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/awscli:2.0.24
+      Environment=NAME=%p.service
+      ExecStartPre=-/usr/bin/docker stop  $NAME
+      ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
+      ExecStart=/usr/bin/docker run -it --network=host --entrypoint /bin/bash $IMAGE -c "export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id -qs); export volume_ids=$(aws ec2 describe-volumes --filter Name=attachment.instance-id,Values=$instance_id --query Volumes[*].VolumeId --out=text) ; aws ec2 create-tags --resources $volume_ids --tags {{.AdditionalTags}}; echo tagged volumes $volume_ids"
+
+      [Install]
+      WantedBy=multi-user.target
+  - name: tag-ebs-volumes.timer
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Execute tag-ebs-volumes.service every hour
+
+      [Timer]
+      OnCalendar=*-*-* *:00:00 UTC
+
+      [Install]
+      WantedBy=multi-user.target
+{{end}}
 {{end}}
   - name: k8s-setup-network-env.service
     enabled: true

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -466,8 +466,8 @@ systemd:
     contents: |
       [Unit]
       Description=Tag all EBS volumes attached to the machine with proper tags
-      After=docker.service etcd3.service
-      Requires=docker.service etcd3.service
+      After=docker.service
+      Requires=docker.service
 
       [Service]
       Type=oneshot


### PR DESCRIPTION
add service to tag all EBS volumes attached to an AWS instance to ensure all tags have the additional tags
towards https://github.com/giantswarm/vodafone/issues/493