### PR TITLE
fix-aws-cni-xtables

### DIFF
--- a/templates/files/k8s-resource/aws-cni.yaml
+++ b/templates/files/k8s-resource/aws-cni.yaml
@@ -246,6 +246,7 @@ spec:
             path: /etc/cni/net.d
         - hostPath:
             path: /run/xtables.lock
+            type: FileOrCreate
           name: xtables-lock
         - hostPath:
             path: /var/log/aws-routed-eni


### PR DESCRIPTION
new version of flatcar could cause issue where the table file is missing and it will be mounted as dir and cause errors