### PR TITLE
In azure, force service principal credentials to be explicitely set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- In azure, force service principal credentials to be explicitely set.
+
 ## [5.8.1] - 2022-01-05
 
 ## [5.8.0] - 2022-01-05

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -3,6 +3,11 @@ provider "azurerm" {
   metadata_host              = var.metadata_host
   environment                = var.environment
   skip_provider_registration = true
+
+  subscription_id = var.azure_sp_subscriptionid
+  client_id       = var.azure_client_id
+  client_secret   = var.azure_client_secret
+  tenant_id       = var.azure_sp_tenantid
 }
 
 data "azurerm_client_config" "current" {}

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -1,3 +1,13 @@
+variable "azure_client_id" {
+  type        = string
+  description = "The Azure API client (application) ID"
+}
+
+variable "azure_client_secret" {
+  type        = string
+  description = "The Azure API client (application) secret"
+}
+
 variable "github_token" {
   type        = string
   description = "Your personal GITHUB token, used to get access to the private repository 'employees' to get the list of users."


### PR DESCRIPTION
On azure, when running terraform from the SREs machines, we used to rely on the locally set up credentials to interact with azure API.

This proved to be unreliable and ineffective for a couple of reasons:

- lighthouse access that we request to customers for our own access does not have all required permissions
- CI/CD uses a different authentication method, leading to problems

With this PR we force the presence of service principal credentials as variables.