### PR TITLE
Bump components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump policy-only manifests to calico 3.21.3 (currently used by AWS only).
+- Bump etcd to 3.4.18.
+
 ## [5.10.0] - 2022-01-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump policy-only manifests to calico 3.21.3 (currently used by AWS only).
 - Bump etcd to 3.4.18.
+- Bump kubernetes to 1.21.9 (AWS).
 
 ## [5.10.0] - 2022-01-19
 

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -145,7 +145,7 @@ variable "docker_registry" {
 
 variable "hyperkube_version" {
   type    = string
-  default = "1.21.8"
+  default = "1.21.9"
 }
 
 ### DNS ###

--- a/templates/files/conf/k8s-addons
+++ b/templates/files/conf/k8s-addons
@@ -90,6 +90,10 @@ done
 $KUBECTL delete pods -l k8s-app=kube-proxy -n kube-system
 
 {{ if eq .Provider "aws" -}}
+$KUBECTL apply -f /srv/calico-crd-installer-rbac.yaml
+$KUBECTL apply -f /srv/calico-crd-installer.yaml
+$KUBECTL wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-crd-installer
+
 ## Apply AWS VPC CNI and Calico for ensuring network policies (only on AWS)
 CNI_FILE="aws-cni.yaml calico-policy-only.yaml"
 {{ else -}}

--- a/templates/files/k8s-resource/calico-crd-installer-rbac.yaml
+++ b/templates/files/k8s-resource/calico-crd-installer-rbac.yaml
@@ -1,0 +1,69 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: calico-init
+spec:
+  allowedHostPaths:
+    - pathPrefix: /etc/kubernetes
+      readOnly: true
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  privileged: false
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  volumes:
+    - hostPath
+    - secret
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: calico-init
+  name: calico-init
+  namespace: kube-system
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: calico-init
+  name: calico-init
+rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - "*"
+  - apiGroups:
+    - policy
+    resources:
+    - podsecuritypolicies
+    resourceNames:
+    - calico-init
+    verbs:
+    - use
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: calico-init
+  name: calico-init
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-init
+subjects:
+  - kind: ServiceAccount
+    name: calico-init
+    namespace: kube-system

--- a/templates/files/k8s-resource/calico-crd-installer.yaml
+++ b/templates/files/k8s-resource/calico-crd-installer.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/name: calico-crd-installer
+  name: calico-crd-installer-v3.21.3
+  namespace: kube-system
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: calico-crd-installer
+    spec:
+      containers:
+        - name: crd-installer
+          image: {{ .DockerRegistry }}/giantswarm/calico-crd-installer:v3.21.3
+      hostNetwork: true
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      restartPolicy: Never
+      serviceAccountName: calico-init
+  backoffLimit: 4

--- a/templates/files/k8s-resource/calico-policy-only.yaml
+++ b/templates/files/k8s-resource/calico-policy-only.yaml
@@ -1,16 +1,11 @@
-
+# Manifests got from https://docs.projectcalico.org/archive/v3.21/manifests/calico.yaml
+#
 # Extra changes:
 #  - Added resource limits to calico-node.
 #  - Added resource limits to install-cni.
-#  - Made install-cni initContainer.
-#  - Added 'priorityClassName: system-cluster-critical' to calico daemonset and calico typha deployment.
+#  - Remove flexvol init Container from calico-node daemonset.
 #
-# Calico Version v3.10.1
-# https://docs.projectcalico.org/v3.10/release-notes/
-# This manifest includes the following component versions:
-#   calico/node:v3.10.1
-#   calico/cni:v3.10.1
-#   calico/typha:v3.10.1
+# https://projectcalico.docs.tigera.io/archive/v3.21/release-notes/
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -34,6 +29,7 @@ data:
         {
           "type": "calico",
           "log_level": "info",
+          "log_file_path": "/var/log/calico/cni/cni.log",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": 1500,
@@ -52,6 +48,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }
@@ -120,7 +120,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-node-critical
       containers:
-        - image: {{ .DockerRegistry }}/giantswarm/typha:v3.10.1
+        - image: {{ .DockerRegistry }}/giantswarm/typha:v3.21.3
           name: calico-typha
           ports:
             - containerPort: 5473
@@ -167,219 +167,6 @@ spec:
 
 ---
 
-# Create all the CustomResourceDefinitions needed for
-# Calico policy-only mode.
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: felixconfigurations.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamblocks.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPAMBlock
-    plural: ipamblocks
-    singular: ipamblock
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: blockaffinities.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BlockAffinity
-    plural: blockaffinities
-    singular: blockaffinity
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamhandles.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPAMHandle
-    plural: ipamhandles
-    singular: ipamhandle
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamconfigs.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPAMConfig
-    plural: ipamconfigs
-    singular: ipamconfig
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: bgpconfigurations.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BGPConfiguration
-    plural: bgpconfigurations
-    singular: bgpconfiguration
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ippools.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPPool
-    plural: ippools
-    singular: ippool
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: hostendpoints.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: HostEndpoint
-    plural: hostendpoints
-    singular: hostendpoint
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterinformations.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: ClusterInformation
-    plural: clusterinformations
-    singular: clusterinformation
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworkpolicies.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkPolicy
-    plural: globalnetworkpolicies
-    singular: globalnetworkpolicy
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworksets.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkSet
-    plural: globalnetworksets
-    singular: globalnetworkset
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networkpolicies.crd.projectcalico.org
-spec:
-  scope: Namespaced
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    singular: networkpolicy
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networksets.crd.projectcalico.org
-spec:
-  scope: Namespaced
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: NetworkSet
-    plural: networksets
-    singular: networkset
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networksets.crd.projectcalico.org
-spec:
-  scope: Namespaced
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: NetworkSet
-    plural: networksets
-    singular: networkset
-
----
-
-
 # This manifest installs the calico-node container, as well
 # as the CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
@@ -389,6 +176,8 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
+    app.kubernetes.io/name: calico-node
+    giantswarm.io/service-type: managed
     k8s-app: calico-node
 spec:
   selector:
@@ -401,13 +190,20 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: calico-node
+        giantswarm.io/service-type: managed
         k8s-app: calico-node
+        giantswarm.io/monitoring: "true"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9091"
+        giantswarm.io/monitoring-path: "/metrics"
+        giantswarm.io/monitoring-port: "9091"
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -431,8 +227,13 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .DockerRegistry }}/giantswarm/cni:v3.10.1
-          command: ["/install-cni.sh"]
+          image: {{ .DockerRegistry }}/giantswarm/cni:v3.21.3
+          command: ["/opt/cni/bin/install"]
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
@@ -460,23 +261,24 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+          securityContext:
+            privileged: true
       {{ end -}}
       containers:
-        # Runs calico-node container on each Kubernetes node.  This
+        # Runs calico-node container on each Kubernetes node. This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .DockerRegistry }}/giantswarm/node:v3.10.1
+          image: {{ .DockerRegistry }}/giantswarm/node:v3.21.3
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Typha support: controlled by the ConfigMap.
-            - name: FELIX_TYPHAK8SSERVICENAME
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: typha_service_name
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -490,33 +292,49 @@ spec:
               value: "none"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
-              value: "k8s,ecs"
-            # Disable file logging so kubectl logs works.
+              value: "k8s"
+            # Non-calico CNI, disable credential management.
+            - name: CALICO_MANAGE_CNI
+              value: "false"
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # - name: CALICO_IPV4POOL_CIDR
+            #   value: "192.168.0.0/16"
+            # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            - name: FELIX_IPTABLESMANGLEALLOWACTION
-              value: Return
-            - name: FELIX_INTERFACEPREFIX
-              value: eni
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
+            - name: FELIX_IPTABLESMANGLEALLOWACTION
+              value: Return
+            {{ if eq .Provider "aws" -}}
+            - name: FELIX_INTERFACEPREFIX
+              value: eni
+            {{- end }}
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
             - name: FELIX_HEALTHENABLED
               value: "true"
             - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "true"  
+              value: "true"
           securityContext:
             privileged: true
           resources:
             requests:
               cpu: 250m
               memory: 150Mi
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/calico-node
+                  - -shutdown
           livenessProbe:
             exec:
               command:
@@ -525,13 +343,19 @@ spec:
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
+            timeoutSeconds: 10
           readinessProbe:
             exec:
               command:
                 - /bin/calico-node
                 - -felix-ready
             periodSeconds: 10
+            timeoutSeconds: 10
           volumeMounts:
+            # For maintaining CNI plugin API credentials.
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -541,6 +365,16 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
+            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
+            # parent directory.
+            - name: sysfs
+              mountPath: /sys/fs/
+              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
+              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
+              mountPropagation: Bidirectional
+            - name: cni-log-dir
+              mountPath: /var/log/calico/cni
+              readOnly: true
       volumes:
         # Used by calico-node.
         - name: lib-modules
@@ -552,6 +386,14 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: sysfs
+          hostPath:
+            path: /sys/fs/
+            type: DirectoryOrCreate
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -559,6 +401,10 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        # Used to access CNI logs.
+        - name: cni-log-dir
+          hostPath:
+            path: /var/log/calico/cni
 ---
 
 apiVersion: v1
@@ -584,6 +430,14 @@ rules:
       - namespaces
     verbs:
       - get
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch
+      - list
   - apiGroups: [""]
     resources:
       - endpoints
@@ -593,6 +447,12 @@ rules:
       - watch
       - list
       # Used to discover Typhas.
+      - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
       - get
   - apiGroups: [""]
     resources:
@@ -633,6 +493,7 @@ rules:
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
+      - ipreservations
       - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
@@ -641,6 +502,7 @@ rules:
       - clusterinformations
       - hostendpoints
       - blockaffinities
+      - caliconodestatuses
     verbs:
       - get
       - list
@@ -654,6 +516,12 @@ rules:
     verbs:
       - create
       - update
+  # Calico must update some CRDs.
+  - apiGroups: [ "crd.projectcalico.org" ]
+    resources:
+      - caliconodestatuses
+    verbs:
+      - update
   # Calico stores some configuration information on the node.
   - apiGroups: [""]
     resources:
@@ -662,7 +530,7 @@ rules:
       - get
       - list
       - watch
-  # These permissions are only requried for upgrade from v2.6, and can
+  # These permissions are only required for upgrade from v2.6, and can
   # be removed after upgrade or on fresh installations.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
@@ -671,6 +539,7 @@ rules:
     verbs:
       - create
       - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities
@@ -682,6 +551,25 @@ rules:
       - create
       - update
       - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/templates/files/k8s-resource/vault-token-reviewer.yaml
+++ b/templates/files/k8s-resource/vault-token-reviewer.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: giantswarm
   name: vault-token-reviewer
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: vault-token-reviewer

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -47,6 +47,24 @@ storage:
         id: 0
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{ index .Files "k8s-resource/calico-policy-only.yaml" }}"
+    - path: /srv/calico-crd-installer.yaml
+      filesystem: root
+      mode: 420
+      user:
+        id: 0
+      group:
+        id: 0
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{ index .Files "k8s-resource/calico-crd-installer.yaml" }}"
+    - path: /srv/calico-crd-installer-rbac.yaml
+      filesystem: root
+      mode: 420
+      user:
+        id: 0
+      group:
+        id: 0
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{ index .Files "k8s-resource/calico-crd-installer-rbac.yaml" }}"
 {{ else }}
     - path: /srv/calico-all.yaml
       filesystem: root
@@ -1028,7 +1046,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.4.13
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.4.18
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       {{if eq .Provider "azure" }}EnvironmentFile=-/var/lib/etcd/master-id{{end}}


### PR DESCRIPTION
First bunch of components updates for AWS:

- Bump policy-only manifests to calico 3.21.3 (currently used by AWS only).
- Bump etcd to 3.4.18.
- Bump k8s to 1.21.9 for AWS

Trying to group them in smaller PR for easier review