### PR TITLE
Move Ingress ELB resources in own module (AWS).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move Ingress ELB resources in own module (AWS).
 - Use managed app to deploy nginx ingress controller (AWS).
 - Use managed app to deploy coredns (AWS).
 - Bump flatcar to 3033.2.0 (AWS).

--- a/modules/aws/ingress/lb.tf
+++ b/modules/aws/ingress/lb.tf
@@ -1,3 +1,13 @@
+locals {
+  common_tags = merge(
+  var.additional_tags,
+  map(
+  "giantswarm.io/cluster", var.cluster_name,
+  "giantswarm.io/installation", var.cluster_name,
+  "kubernetes.io/cluster/${var.cluster_name}", "owned"
+  )
+  )
+}
 resource "aws_elb" "worker" {
   name                      = "${var.cluster_name}-worker"
   cross_zone_load_balancing = true
@@ -28,10 +38,10 @@ resource "aws_elb" "worker" {
   }
 
   tags = merge(
-    local.common_tags,
-    map(
-      "Name", "${var.cluster_name}-worker"
-    )
+  local.common_tags,
+  map(
+  "Name", "${var.cluster_name}-worker-elb"
+  )
   )
 }
 
@@ -66,10 +76,10 @@ resource "aws_security_group" "worker_elb" {
   }
 
   tags = merge(
-    local.common_tags,
-    map(
-      "Name", "${var.cluster_name}-worker-elb"
-    )
+  local.common_tags,
+  map(
+  "Name", "${var.cluster_name}-worker-elb"
+  )
   )
 }
 

--- a/modules/aws/ingress/variables.tf
+++ b/modules/aws/ingress/variables.tf
@@ -1,0 +1,26 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "dns_zone_id" {
+  type = string
+}
+
+variable "elb_subnet_ids" {
+  type = list
+}
+
+variable "ingress_dns" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+### additional tags
+variable "additional_tags" {
+  description = "Additional tags that can be added to all resources"
+  type        = map
+  default     = {}
+}

--- a/modules/aws/master/master.tf
+++ b/modules/aws/master/master.tf
@@ -40,7 +40,8 @@ resource "aws_cloudformation_stack" "master_asg" {
         "LaunchConfigurationName": "${element(aws_launch_configuration.master.*.name, count.index)}",
         "LoadBalancerNames": [
           "${var.cluster_name}-master-api",
-          "${var.cluster_name}-master-api-internal"
+          "${var.cluster_name}-master-api-internal",
+          "${var.cluster_name}-worker"
         ],
         "MaxSize": "1",
         "DesiredCapacity": "1",

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -217,6 +217,18 @@ module "vault" {
   worker_subnet_count    = length(module.vpc.worker_subnet_ids)
 }
 
+# Ingress ELB
+module "ingress" {
+  source = "../../../modules/aws/ingress"
+
+  additional_tags = var.additional_tags
+  cluster_name    = var.cluster_name
+  dns_zone_id     = module.dns.public_dns_zone_id
+  elb_subnet_ids  = module.vpc.elb_subnet_ids
+  ingress_dns     = var.ingress_dns
+  vpc_id          = module.vpc.vpc_id
+}
+
 # Generate ignition config.
 data "gotemplate" "master" {
   count = var.master_count


### PR DESCRIPTION
Since we switched to the nginx ingress controller managed app, the nginx ingress controller pods may end up in any worker or master node (it was workers only before).
Since we use `externalTrafficPolicy: local`, only nodes running an nginx ingress controller pod will respond to the ELB.
That means we need to add the master nodes to the ingress ELB (it is managed by terraform).

This makes it necessary to create the ELB before master nodes.
This PR extracts the ingress ELB creation to its own module so it can be run before masters and worker nodes, and changes master nodes in order to add themselves to the ELB.

WARNING: this is a breaking change and will require manual intervention to be applied. I will take care of doing so.