### PR TITLE
Disable use-forwarded-headers for nginx-ingress-controller-app

### DIFF
--- a/templates/files/k8s-resource/ingress-controller-app.yaml
+++ b/templates/files/k8s-resource/ingress-controller-app.yaml
@@ -5,8 +5,9 @@ metadata:
   namespace: giantswarm
 data:
   configmap-values.yaml: |
-{{- if eq .Provider "aws" }}
     configmap:
+      use-forwarded-headers: "false"
+{{- if eq .Provider "aws" }}
       use-proxy-protocol: "true"
 {{- end }}
     controller:


### PR DESCRIPTION
Its enabled by default and is not required for this setup.

Future versions will have this disabled by default anyway.