### PR TITLE
Fix CIDR in Azure CNI masquerading unit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CIDR in Azure CNI masquerading unit.
+
 ## [6.0.0] - 2022-01-28
 
 ### Changed

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -154,6 +154,7 @@ locals {
     "Provider"                 = "azure"
     "Users"                    = yamldecode(base64decode(jsondecode(data.http.bastion_users.body).content))
     "VaultDomainName"          = "${var.vault_dns}.${var.base_domain}"
+    "NodesSubnet"              = cidrsubnet(var.vnet_cidr, 8, 2)
     "VnetCIDR"                 = var.vnet_cidr
   }
 }

--- a/templates/files/conf/azure-cni
+++ b/templates/files/conf/azure-cni
@@ -2,7 +2,7 @@
 
 IPTABLES=/sbin/iptables
 
-RULE="POSTROUTING -t nat -m addrtype ! --dst-type local ! -d {{ .VnetCIDR }} -j MASQUERADE"
+RULE="POSTROUTING -t nat -m addrtype ! --dst-type local ! -d {{ .NodesSubnet }} -j MASQUERADE"
 
 while : ; do
   if $IPTABLES -C ${RULE}


### PR DESCRIPTION
routing was broken for pods towards vault host because of a wrong CIDR in the masquerading unit for azure cni