### PR TITLE
Allow customizing clusterDomain setting in kubelet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow customizing clusterDomain setting in kubelet.
+
 ## [6.1.1] - 2022-02-01
 
 ### Fixed

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -113,6 +113,7 @@ locals {
     "CNISubnets"                   = module.vpc.aws_cni_subnet_ids
     "CNISecurityGroupID"           = module.vpc.aws_cni_security_group_id
     "CloudwatchForwarderEnabled"   = var.bastion_log_priority != "none" ? "true" : "false"
+    "ClusterDomain"                = var.cluster_domain
     "ClusterName"                  = var.cluster_name
     "DockerCIDR"                   = var.docker_cidr
     "DockerRegistry"               = var.docker_registry

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -376,3 +376,10 @@ variable "additional_tags" {
   type        = map(string)
   default     = {}
 }
+
+### cluster domain
+variable "cluster_domain" {
+  description = "clusterDomain setting for kubelet"
+  type        = string
+  default     = "cluster.local"
+}

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -134,6 +134,7 @@ locals {
     "APIInternalDomainName"    = "${var.api_dns_internal}.${var.base_domain}"
     "BaseDomain"               = var.base_domain
     "CalicoMTU"                = var.calico_mtu
+    "ClusterDomain"            = var.cluster_domain
     "ClusterName"              = var.cluster_name
     "DockerCIDR"               = var.docker_cidr
     "DockerRegistry"           = var.docker_registry

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -340,3 +340,10 @@ variable "release_version" {
   type        = string
   default     = ""
 }
+
+### cluster domain
+variable "cluster_domain" {
+  description = "clusterDomain setting for kubelet"
+  type        = string
+  default     = "cluster.local"
+}

--- a/templates/files/config/kubelet-master.yaml.tmpl
+++ b/templates/files/config/kubelet-master.yaml.tmpl
@@ -7,7 +7,7 @@ healthzBindAddress: ${DEFAULT_IPV4}
 healthzPort: 10248
 clusterDNS:
   - {{ .K8SDNSIP }}
-clusterDomain: cluster.local
+clusterDomain: {{ .ClusterDomain }}
 featureGates:
   ExpandPersistentVolumes: true
 staticPodPath: /etc/kubernetes/manifests

--- a/templates/files/config/kubelet-worker.yaml.tmpl
+++ b/templates/files/config/kubelet-worker.yaml.tmpl
@@ -7,7 +7,7 @@ healthzBindAddress: ${DEFAULT_IPV4}
 healthzPort: 10248
 clusterDNS:
   - {{ .K8SDNSIP }}
-clusterDomain: cluster.local
+clusterDomain: {{ .ClusterDomain }}
 featureGates:
   ExpandPersistentVolumes: true
 kernelMemcgNotification: true


### PR DESCRIPTION
`gorilla` has a custom cluster domain (instead of `cluster.local`) but this setting was never really applied. See:

- https://github.com/giantswarm/giantnetes-terraform/blob/v5.10.0/templates/files/config/kubelet-master.yaml.tmpl#L10
- https://github.com/giantswarm/giantnetes-terraform/blob/v5.10.0/templates/files/k8s-resource/coredns-all.yaml#L38

Now that we switched to a managed app for coredns, the setting is actually applied, but kubelets still had the hardcoded values.

This PR makes it possible to specify a custom cluster domain and of course defaults to `cluster.local`