### PR TITLE
Set service CIDR and service IP for Coredns app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set service CIDR and service IP for Coredns app.
+
 ## [6.2.1] - 2022-02-07
 
 ### Added

--- a/templates/files/k8s-resource/coredns-app.yaml
+++ b/templates/files/k8s-resource/coredns-app.yaml
@@ -8,6 +8,10 @@ data:
     cluster:
       kubernetes:
         clusterDomain: {{ .ClusterDomain }}
+        API:
+          clusterIPRange: {{ .K8SServiceCIDR }}
+        DNS:
+          IP: {{ .K8SDNSIP }}
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App


### PR DESCRIPTION
we need to set those or installations with non-default service CIDRS will not work (example flamingo)