### PR TITLE
Bump nginx ingress controller app to 2.9.0 and enable `enable-ssl-chain-completion` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump nginx ingress controller app to 2.9.0 and enable `enable-ssl-chain-completion` flag.
+
 ## [6.2.2] - 2022-02-07
 
 ### Fixed

--- a/templates/files/k8s-resource/ingress-controller-app.yaml
+++ b/templates/files/k8s-resource/ingress-controller-app.yaml
@@ -11,6 +11,7 @@ data:
       use-proxy-protocol: "true"
 {{- end }}
     controller:
+      enableSSLChainCompletion: true
       service:
         type: NodePort
 ---
@@ -49,4 +50,4 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 2.7.0
+  version: 2.9.0


### PR DESCRIPTION
Needed by viking because they use custom SSL certs that need this feature.
It used to be enabled in old nginx ingress controller, was disabled when we moved to the managed app.