### PR TITLE
Azure master roll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switch Azure Master nodes to `azurerm_linux_virtual_machine_scale_set`.
 - Enable azure-scheduled-events for azure masters.
-- Switch to `Manual` rollout mode for azure masters and workers.
 
 ## [6.4.0] - 2022-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switch Azure Master nodes to `azurerm_linux_virtual_machine_scale_set`.
+- Enable azure-scheduled-events for azure masters.
+- Switch to `Manual` rollout mode for azure masters and workers.
+
 ## [6.4.0] - 2022-02-11
 
 ### Changed

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -21,17 +21,17 @@ resource "azurerm_linux_virtual_machine_scale_set" "masters" {
   sku = var.vm_size
   instances = var.master_count
 
-  upgrade_policy_mode = "Manual"
-  health_probe_id     = var.node_health_probe_id
+  upgrade_mode    = "Manual"
+  health_probe_id = var.node_health_probe_id
   terminate_notification {
     enabled = true
     timeout = "PT5M"
   }
   network_interface {
-    name                   = "master-nic-0"
-    primary                = true
-    accelerated_networking = var.enable_accelerated_networking
-    ip_forwarding          = true
+    name                          = "master-nic-0"
+    primary                       = true
+    enable_accelerated_networking = var.enable_accelerated_networking
+    enable_ip_forwarding          = true
     ip_configuration {
       name      = "master-ipconfig-0"
       primary   = true

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -21,7 +21,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "masters" {
   sku = var.vm_size
   instances = var.master_count
 
-  upgrade_mode    = "Manual"
+  upgrade_mode    = "Rolling"
   health_probe_id = var.node_health_probe_id
   terminate_notification {
     enabled = true

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -13,20 +13,21 @@ resource "azurerm_managed_disk" "master_etcd" {
   }
 }
 
-resource "azurerm_virtual_machine_scale_set" "masters" {
+resource "azurerm_linux_virtual_machine_scale_set" "masters" {
   location            = var.location
   name                = "${var.cluster_name}-masters"
   resource_group_name = var.resource_group_name
 
-  upgrade_policy_mode = "Rolling"
+  sku = var.vm_size
+  instances = var.master_count
+
+  upgrade_policy_mode = "Manual"
   health_probe_id     = var.node_health_probe_id
-  rolling_upgrade_policy {
-    max_batch_instance_percent              = 40
-    max_unhealthy_instance_percent          = 40
-    max_unhealthy_upgraded_instance_percent = 40
-    pause_time_between_batches              = "PT30S"
+  terminate_notification {
+    enabled = true
+    timeout = "PT5M"
   }
-  network_profile {
+  network_interface {
     name                   = "master-nic-0"
     primary                = true
     accelerated_networking = var.enable_accelerated_networking
@@ -44,40 +45,30 @@ resource "azurerm_virtual_machine_scale_set" "masters" {
     publisher = "kinvolk"
     product   = "flatcar-container-linux-free"
   }
-  os_profile {
-    admin_username       = "core"
-    computer_name_prefix = "master-"
-    custom_data          = base64encode(data.ignition_config.loader.rendered)
+  admin_username       = "core"
+  computer_name_prefix = "master-"
+  custom_data          = base64encode(data.ignition_config.loader.rendered)
+  disable_password_authentication = true
+  admin_ssh_key {
+    username   = "core"
+    public_key = var.core_ssh_key
   }
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/core/.ssh/authorized_keys"
-      key_data = var.core_ssh_key
-    }
-  }
-  sku {
-    name     = var.vm_size
-    capacity = var.master_count
-    tier     = "standard"
-  }
-  storage_profile_image_reference {
+  source_image_reference {
     publisher = "kinvolk"
     offer     = "flatcar-container-linux-free"
     sku       = var.flatcar_linux_channel
     version   = var.flatcar_linux_version
   }
-  storage_profile_os_disk {
-    managed_disk_type = var.os_disk_storage_type
-    create_option     = "FromImage"
-    caching           = "ReadWrite"
-    os_type           = "linux"
+  os_disk {
+    storage_account_type = var.os_disk_storage_type
+    caching              = "ReadWrite"
   }
-  storage_profile_data_disk {
-    create_option     = "Empty"
-    lun               = 0
-    disk_size_gb      = var.docker_disk_size
-    managed_disk_type = var.storage_type
+  data_disk {
+    create_option        = "Empty"
+    lun                  = 0
+    disk_size_gb         = var.docker_disk_size
+    storage_account_type = var.storage_type
+    caching              = "None"
   }
   identity {
     type = "SystemAssigned"
@@ -102,5 +93,5 @@ resource "azurerm_virtual_machine_scale_set" "masters" {
 resource "azurerm_role_assignment" "vmss_contributor" {
   scope                = var.resource_group_id
   role_definition_name = "Contributor"
-  principal_id         = azurerm_virtual_machine_scale_set.masters.identity[0].principal_id
+  principal_id         = azurerm_linux_virtual_machine_scale_set.masters.identity[0].principal_id
 }

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -27,6 +27,12 @@ resource "azurerm_linux_virtual_machine_scale_set" "masters" {
     enabled = true
     timeout = "PT5M"
   }
+  rolling_upgrade_policy {
+    max_batch_instance_percent              = 40
+    max_unhealthy_instance_percent          = 40
+    max_unhealthy_upgraded_instance_percent = 40
+    pause_time_between_batches              = "PT30S"
+  }
   network_interface {
     name                          = "master-nic-0"
     primary                       = true

--- a/modules/azure/vnet/lb-ingress.tf
+++ b/modules/azure/vnet/lb-ingress.tf
@@ -90,7 +90,7 @@ resource "azurerm_lb_rule" "ingress_ssh_lb" {
 }
 
 # TODO delete this once deployed in all azure MCs.
-resource "azurerm_lb_rule" "ingress_ssh_lb" {
+resource "azurerm_lb_rule" "ingress_ssh_lb_legacy" {
   name                     = "ingress-lb-fake-rule-for-node-health-legacy"
   resource_group_name      = var.resource_group_name
   loadbalancer_id          = azurerm_lb.api_lb.id

--- a/modules/azure/vnet/lb-ingress.tf
+++ b/modules/azure/vnet/lb-ingress.tf
@@ -81,7 +81,7 @@ resource "azurerm_lb_rule" "ingress_ssh_lb" {
   resource_group_name      = var.resource_group_name
   loadbalancer_id          = azurerm_lb.api_lb.id
   backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-lb.id]
-  probe_id                 = azurerm_lb_probe.ssh.id
+  probe_id                 = azurerm_lb_probe.kubelet.id
 
   protocol                       = "udp"
   frontend_port                  = 65000

--- a/modules/azure/vnet/lb-ingress.tf
+++ b/modules/azure/vnet/lb-ingress.tf
@@ -51,11 +51,11 @@ resource "azurerm_lb_probe" "ingress_30010_lb" {
 }
 
 resource "azurerm_lb_rule" "ingress_https_lb" {
-  name                    = "ingress-lb-rule-443-30011"
-  resource_group_name     = var.resource_group_name
-  loadbalancer_id         = azurerm_lb.api_lb.id
-  backend_address_pool_id = azurerm_lb_backend_address_pool.api-lb.id
-  probe_id                = azurerm_lb_probe.ingress_30011_lb.id
+  name                     = "ingress-lb-rule-443-30011"
+  resource_group_name      = var.resource_group_name
+  loadbalancer_id          = azurerm_lb.api_lb.id
+  backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-lb.id]
+  probe_id                 = azurerm_lb_probe.ingress_30011_lb.id
 
   protocol                       = "tcp"
   frontend_port                  = 443
@@ -77,11 +77,11 @@ resource "azurerm_lb_probe" "ingress_30011_lb" {
 # This probe has to be referenced by an active forwarding rule.
 # Since we don't want to expose SSH through the load balancer, we use random port 65000.
 resource "azurerm_lb_rule" "ingress_ssh_lb" {
-  name                    = "ingress-lb-fake-rule-for-node-health"
-  resource_group_name     = var.resource_group_name
-  loadbalancer_id         = azurerm_lb.api_lb.id
-  backend_address_pool_id = azurerm_lb_backend_address_pool.api-lb.id
-  probe_id                = azurerm_lb_probe.ssh.id
+  name                     = "ingress-lb-fake-rule-for-node-health"
+  resource_group_name      = var.resource_group_name
+  loadbalancer_id          = azurerm_lb.api_lb.id
+  backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-lb.id]
+  probe_id                 = azurerm_lb_probe.ssh.id
 
   protocol                       = "udp"
   frontend_port                  = 65000

--- a/modules/azure/vnet/lb-ingress.tf
+++ b/modules/azure/vnet/lb-ingress.tf
@@ -98,8 +98,8 @@ resource "azurerm_lb_rule" "ingress_ssh_lb_legacy" {
   probe_id                 = azurerm_lb_probe.ssh.id
 
   protocol                       = "udp"
-  frontend_port                  = 65000
-  backend_port                   = 65000
+  frontend_port                  = 65001
+  backend_port                   = 65001
   frontend_ip_configuration_name = "ingress"
 }
 

--- a/modules/azure/vnet/lb-ingress.tf
+++ b/modules/azure/vnet/lb-ingress.tf
@@ -30,11 +30,11 @@ resource "azurerm_dns_a_record" "ingress_wildcard_dns" {
 }
 
 resource "azurerm_lb_rule" "ingress_http_lb" {
-  name                    = "ingress-lb-rule-80-30010"
-  resource_group_name     = var.resource_group_name
-  loadbalancer_id         = azurerm_lb.api_lb.id
-  backend_address_pool_id = azurerm_lb_backend_address_pool.api-lb.id
-  probe_id                = azurerm_lb_probe.ingress_30010_lb.id
+  name                     = "ingress-lb-rule-80-30010"
+  resource_group_name      = var.resource_group_name
+  loadbalancer_id          = azurerm_lb.api_lb.id
+  backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-lb.id]
+  probe_id                 = azurerm_lb_probe.ingress_30010_lb.id
 
   protocol                       = "tcp"
   frontend_port                  = 80

--- a/modules/azure/vnet/lb-ingress.tf
+++ b/modules/azure/vnet/lb-ingress.tf
@@ -90,6 +90,20 @@ resource "azurerm_lb_rule" "ingress_ssh_lb" {
 }
 
 # TODO delete this once deployed in all azure MCs.
+resource "azurerm_lb_rule" "ingress_ssh_lb" {
+  name                     = "ingress-lb-fake-rule-for-node-health-legacy"
+  resource_group_name      = var.resource_group_name
+  loadbalancer_id          = azurerm_lb.api_lb.id
+  backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-lb.id]
+  probe_id                 = azurerm_lb_probe.ssh.id
+
+  protocol                       = "udp"
+  frontend_port                  = 65000
+  backend_port                   = 65000
+  frontend_ip_configuration_name = "ingress"
+}
+
+# TODO delete this once deployed in all azure MCs.
 resource "azurerm_lb_probe" "ssh" {
   name                = "ssh-probe"
   loadbalancer_id     = azurerm_lb.api_lb.id

--- a/modules/azure/vnet/lb-internal-api.tf
+++ b/modules/azure/vnet/lb-internal-api.tf
@@ -25,7 +25,6 @@ resource "azurerm_dns_a_record" "api_dns_internal" {
 
 resource "azurerm_lb_backend_address_pool" "api-lb-internal" {
   name                = "api-lb-pool-internal"
-  resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.api_lb_internal.id
 }
 

--- a/modules/azure/worker-as/worker-as.tf
+++ b/modules/azure/worker-as/worker-as.tf
@@ -9,6 +9,12 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   instances      = var.min_worker_count
   sku            = var.vm_size
 
+  rolling_upgrade_policy {
+    max_batch_instance_percent              = 40
+    max_unhealthy_instance_percent          = 40
+    max_unhealthy_upgraded_instance_percent = 40
+    pause_time_between_batches              = "PT30S"
+  }
   terminate_notification {
     enabled = true
     timeout = "PT5M"

--- a/modules/azure/worker-as/worker-as.tf
+++ b/modules/azure/worker-as/worker-as.tf
@@ -2,19 +2,13 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   location            = var.location
   name                = "${var.cluster_name}-workers"
   resource_group_name = var.resource_group_name
-  upgrade_mode        = "Rolling"
+  upgrade_mode        = "Manual"
   health_probe_id     = var.node_health_probe_id
 
   admin_username = "core"
   instances      = var.min_worker_count
   sku            = var.vm_size
 
-  rolling_upgrade_policy {
-    max_batch_instance_percent              = 40
-    max_unhealthy_instance_percent          = 40
-    max_unhealthy_upgraded_instance_percent = 40
-    pause_time_between_batches              = "PT30S"
-  }
   terminate_notification {
     enabled = true
     timeout = "PT5M"

--- a/modules/azure/worker-as/worker-as.tf
+++ b/modules/azure/worker-as/worker-as.tf
@@ -2,7 +2,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   location            = var.location
   name                = "${var.cluster_name}-workers"
   resource_group_name = var.resource_group_name
-  upgrade_mode        = "Manual"
+  upgrade_mode        = "Rolling"
   health_probe_id     = var.node_health_probe_id
 
   admin_username = "core"

--- a/templates/files/conf/attach-etcd-disk
+++ b/templates/files/conf/attach-etcd-disk
@@ -155,3 +155,6 @@ master_id_file="${MOUNTPOINT}/master-id"
 echo "Writing master ID ${MASTER_ID} to ${master_id_file}"
 
 echo "MASTER_ID=${MASTER_ID}" >$master_id_file
+
+docker kill azure-cli || true
+docker rm azure-cli || true

--- a/templates/files/conf/attach-etcd-disk
+++ b/templates/files/conf/attach-etcd-disk
@@ -25,10 +25,15 @@ resourceid="$(echo "$metadata" | jq -r .compute.resourceId)"
 # Extract instance ID (a number) from the resource ID.
 INSTANCEID="$(echo $resourceid | grep -Eo '[0-9]+$')"
 
+# Run a container with azure-cli.
+docker kill azure-cli || true
+docker run --name azure-cli -d mcr.microsoft.com/azure-cli sleep infinity
+docker exec azure-cli az login --identity || (echo "Failed logging in with Azure cli."; exit 1)
+
 run_az_cmd () {
   cmd="$1"
 
-  docker run --rm mcr.microsoft.com/azure-cli bash -c "az login --identity 2>&1 >/dev/null && $cmd"
+  docker exec azure-cli $cmd
 }
 
 if [ -f "$DISK" ] || [ -h "$DISK" ]

--- a/templates/files/conf/attach-etcd-disk
+++ b/templates/files/conf/attach-etcd-disk
@@ -27,6 +27,7 @@ INSTANCEID="$(echo $resourceid | grep -Eo '[0-9]+$')"
 
 # Run a container with azure-cli.
 docker kill azure-cli || true
+docker rm azure-cli || true
 docker run --name azure-cli -d mcr.microsoft.com/azure-cli sleep infinity
 docker exec azure-cli az login --identity || (echo "Failed logging in with Azure cli."; exit 1)
 
@@ -68,7 +69,7 @@ else
   # list all disks with tag GiantSwarmRole == "etcd" and having a GiantSwarmEtcdID tag
   echo "Looking for available disks"
   # TODO discard disks with multi-attach feature enabled when az will support it
-  candidates="$(run_az_cmd "az disk list -g ${RESOURCEGROUP} | jq '. | map(select(.tags.GiantSwarmRole == \"etcd\" and .diskState == \"Unattached\" and (.tags | has(\"GiantSwarmEtcdID\"))))'")"
+  candidates="$(run_az_cmd "az disk list -g ${RESOURCEGROUP}" | jq '. | map(select(.tags.GiantSwarmRole == "etcd" and .diskState == "Unattached" and (.tags | has("GiantSwarmEtcdID"))))')"
 
   if [ "$candidates" == "[]" ]
   then


### PR DESCRIPTION
Towards: https://github.com/giantswarm/installations/runs/5234134673?check_suite_focus=true

- Using the new `azurerm_linux_virtual_machine_scale_set` terraform resource in place of the deprecated `azurerm_virtual_machine_scale_set`.
- Enable termination notification on masters to make azure-scheduled-events effective.
