### PR TITLE
Split worker nodes in different ASGs, each one having a single AZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split worker nodes in different ASGs, each one having a single availability zone to ease cluster-autoscaler's decisions.
+
 ## [6.6.0] - 2022-02-18
 
 ### Changed

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -28,7 +28,7 @@ resource "aws_cloudformation_stack" "worker_asg_single_az" {
         "DesiredCapacity": "2",
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": 300,
-        "LaunchConfigurationName": "${aws_launch_configuration.worker.name}",
+        "LaunchConfigurationName": "${aws_launch_configuration.worker_asg_single_az.name}",
         "LoadBalancerNames": [
           "${var.cluster_name}-worker"
         ],

--- a/modules/aws/worker-asg/worker-asg.tf
+++ b/modules/aws/worker-asg/worker-asg.tf
@@ -90,8 +90,8 @@ resource "aws_cloudformation_stack" "worker_asg_single_az" {
 EOF
 }
 
-resource "aws_launch_configuration" "worker" {
-  name_prefix          = "${var.cluster_name}-worker-"
+resource "aws_launch_configuration" "worker_asg_single_az" {
+  name_prefix          = "${var.cluster_name}-worker-singleaz-"
   iam_instance_profile = aws_iam_instance_profile.worker.name
   image_id             = var.container_linux_ami_id
   instance_type        = var.instance_type


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20953

this PR splits the worker nodes into different ASGs, in order for cluster-autoscaler to be able to scale the right AZ based on the needed availability zone.

This is the first step, where the old ASG is still present. It has to be removed in a follow up PR in order to avoid downtimes during rollout.

It goes along with this change in the deployment CI https://github.com/giantswarm/installations/pull/1980

currently running in ginger.