### PR TITLE
Add `--tls-cipher-suites` flag to api-server manifest to disable vulnerable ciphers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--tls-cipher-suites` flag to api-server manifest to disable vulnerable ciphers.
+
 ## [8.0.0] - 2022-03-01
 
 ### Added

--- a/templates/files/manifests/api-server.yaml
+++ b/templates/files/manifests/api-server.yaml
@@ -48,6 +48,7 @@ spec:
       - --service-account-lookup=true
       - --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
       - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+      - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
       - --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
       - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-key.pem


### PR DESCRIPTION
Towards: https://github.com/giantswarm/vodafone/issues/522

we didn't specify the tls ciphers to be exposed by API server. Default is golang's default and apparently those include vulnerable ciphers.

The list of ciphers is taken from [k8s documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) 