### PR TITLE
Set `fs.inotify.max_user_instances` to 1024 to avoid `Too many open f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create /srv/apps/ directory with all `App` CR manifests in order to simplify `k8s-addons` script.
 - Bump azure-scheduled-events app to 0.7.0.
+- Set `fs.inotify.max_user_instances` to 1024 to avoid `Too many open files` error.
 
 ## [8.1.0] - 2022-03-10
 

--- a/templates/files/conf/hardening.conf
+++ b/templates/files/conf/hardening.conf
@@ -3,6 +3,7 @@ net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.all.arp_ignore = 1
 net.ipv4.conf.all.arp_announce = 2
 fs.inotify.max_user_watches = 16384
+fs.inotify.max_user_instances = 1024
 kernel.kptr_restrict = 2
 kernel.sysrq = 0
 net.ipv4.conf.all.send_redirects = 0


### PR DESCRIPTION
…iles` error.

