### PR TITLE
Switch to Manual rolling mode for azure nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump azurerm provider to 3.0.2.
+- Switch to Manual rolling mode for azure nodes.
 
 ## [8.2.0] - 2022-03-28
 

--- a/modules/azure/master-as/master-as.tf
+++ b/modules/azure/master-as/master-as.tf
@@ -21,17 +21,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "masters" {
   sku = var.vm_size
   instances = var.master_count
 
-  upgrade_mode    = "Rolling"
+  upgrade_mode    = "Manual"
   health_probe_id = var.node_health_probe_id
   terminate_notification {
     enabled = true
     timeout = "PT5M"
-  }
-  rolling_upgrade_policy {
-    max_batch_instance_percent              = 40
-    max_unhealthy_instance_percent          = 40
-    max_unhealthy_upgraded_instance_percent = 40
-    pause_time_between_batches              = "PT30S"
   }
   network_interface {
     name                          = "master-nic-0"
@@ -91,6 +85,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "masters" {
   timeouts {
     create = "60m"
     delete = "2h"
+  }
+  lifecycle {
+    ignore_changes = [rolling_upgrade_policy]
   }
 }
 

--- a/modules/azure/worker-as/worker-as.tf
+++ b/modules/azure/worker-as/worker-as.tf
@@ -2,19 +2,13 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   location            = var.location
   name                = "${var.cluster_name}-workers"
   resource_group_name = var.resource_group_name
-  upgrade_mode        = "Rolling"
+  upgrade_mode        = "Manual"
   health_probe_id     = var.node_health_probe_id
 
   admin_username = "core"
   instances      = var.min_worker_count
   sku            = var.vm_size
 
-  rolling_upgrade_policy {
-    max_batch_instance_percent              = 40
-    max_unhealthy_instance_percent          = 40
-    max_unhealthy_upgraded_instance_percent = 40
-    pause_time_between_batches              = "PT30S"
-  }
   terminate_notification {
     enabled = true
     timeout = "PT5M"
@@ -81,7 +75,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   }
 
   lifecycle {
-    ignore_changes = [instances]
+    ignore_changes = [instances,rolling_upgrade_policy]
   }
 }
 

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -1,5 +1,9 @@
 provider "azurerm" {
-  features {}
+  features {
+    virtual_machine_scale_set {
+      roll_instances_when_required = false
+    }
+  }
   metadata_host              = var.metadata_host
   environment                = var.environment
   skip_provider_registration = true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/966

we can't rely on neither azure not terraform to properly roll nodes on updates.
We do it ourselves using the CI scripts (in the `installations` repo) so we need to disable all automated rolling features.