### PR TITLE
Ignore AZ setting for public API LB on azure to avoid unsolvable conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore AZ setting for public API LB on azure to avoid unsolvable conflict.
+
 ## [8.4.0] - 2022-03-30
 
 ### Added

--- a/modules/azure/vnet/lb-public.tf
+++ b/modules/azure/vnet/lb-public.tf
@@ -40,6 +40,10 @@ resource "azurerm_public_ip" "api_ip" {
   tags = merge(local.common_tags, map(
     "GiantSwarmInstallation", var.cluster_name
   ))
+
+  lifecycle {
+    ignore_changes = [zones]
+  }
 }
 
 resource "azurerm_dns_a_record" "api_dns" {


### PR DESCRIPTION
Needed to fix a rollout error on `icecream`.