### PR TITLE
Bump versions for azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Azure] Switch to CSI storage provider.
 - [Azure] Enable `CSIMigration` and `CSIMigrationAzureDisk` feature gates.
 - [Azure] Bump flatcar to `3139.2.0`.
-- [Azure] Bump coredns to `1.9.0`.
-- [Azure] Bump nginx-ingress-controller to `2.10.0`.
+- Bump coredns to `1.9.0`.
+- Bump nginx-ingress-controller to `2.10.0`.
 
 ## [8.4.1] - 2022-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Azure] Add apps for out-of-tree cloud provider integration.
 - [Azure] Switch to CSI storage provider.
 - [Azure] Enable `CSIMigration` and `CSIMigrationAzureDisk` feature gates.
+- [Azure] Bump flatcar to `3139.2.0`.
+- [Azure] Bump coredns to `1.9.0`.
+- [Azure] Bump nginx-ingress-controller to `2.10.0`.
 
 ## [8.4.1] - 2022-03-30
 

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -138,7 +138,7 @@ variable "flatcar_linux_channel" {
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
   type        = string
-  default     = "3033.2.4"
+  default     = "3139.2.0"
 }
 
 variable "vault_image_publisher" {

--- a/templates/files/apps/common/coredns-app.yaml
+++ b/templates/files/apps/common/coredns-app.yaml
@@ -49,4 +49,4 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 1.8.0
+  version: 1.9.0

--- a/templates/files/apps/common/ingress-controller-app.yaml
+++ b/templates/files/apps/common/ingress-controller-app.yaml
@@ -50,4 +50,4 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 2.9.0
+  version: 2.10.0


### PR DESCRIPTION
- [Azure] Bump flatcar to `3139.2.0`.
- [Azure] Bump coredns to `1.9.0`.
- [Azure] Bump nginx-ingress-controller to `2.10.0`.