### PR TITLE
Apps: Bump nginx-ingress-controller-app to v2.11.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `nginx-ingress-controller-app` to `2.11.0`.
+
 ## [9.0.0] - 2022-04-19
 
 ### Changed

--- a/templates/files/apps/common/ingress-controller-app.yaml
+++ b/templates/files/apps/common/ingress-controller-app.yaml
@@ -50,4 +50,4 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 2.10.0
+  version: 2.11.0


### PR DESCRIPTION
Partially resolves https://github.com/giantswarm/giantswarm/issues/21596.