### PR TITLE
Fix networking issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [AWS] Disable kernel route for eth1 interface to avoid routing trouble within AZ.
+
 ## [9.2.0] - 2022-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [AWS] Disable kernel route for eth1 interface to avoid routing trouble within AZ.
+- Bind Api Server to 0.0.0.0.
+- Remove Api Server advertise address to make it be automatic set to VM's default IP address.
 
 ## [9.2.0] - 2022-05-05
 

--- a/templates/files/manifests/api-server.yaml
+++ b/templates/files/manifests/api-server.yaml
@@ -16,11 +16,6 @@ spec:
   containers:
     - name: k8s-api-server
       image: {{.DockerRegistry}}/giantswarm/kube-apiserver:v{{ .K8sVersion }}
-      env:
-      - name: HOST_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
       command:
       - kube-apiserver
       - --allow-privileged=true
@@ -29,7 +24,7 @@ spec:
       {{ if eq .Provider "aws" -}}
       - --cloud-provider=external
       {{ end -}}
-      - --bind-address=$(HOST_IP)
+      - --bind-address=0.0.0.0
       - --etcd-prefix=giantswarm.io
       - --authorization-mode=RBAC
       - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PodSecurityPolicy,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
@@ -38,7 +33,6 @@ spec:
       - --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem
       - --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem
       - --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem
-      - --advertise-address=$(HOST_IP)
       - --runtime-config=api/all=true
       - --logtostderr=true
       - --profiling=false

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1361,7 +1361,6 @@ networkd:
 
       [Address]
       Address={{.MasterENIAddress}}/{{.MasterENISubnetSize}}
-      AddPrefixRoute=false
       RouteMetric=2000
 
       [RoutingPolicyRule]

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1358,8 +1358,11 @@ networkd:
       # ensure that traffic arriving on eth1 leaves again from eth1 to prevent asymetric routing
       [Match]
       Name=eth1
-      [Network]
+
+      [Address]
       Address={{.MasterENIAddress}}/{{.MasterENISubnetSize}}
+      AddPrefixRoute=false
+      RouteMetric=2000
 
       [RoutingPolicyRule]
       Table=2


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21994

because of a suspect bug in flatcar and a wrong config on the network on our side, worker nodes can't talk to API server in the same AZ.

this PR changes some network settings and kubelet binding address to avoid the problem until upstream fixes the issue and allows better configurability