### PR TITLE
- [Azure] Bump kubernetes to version 1.22.10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Azure] Bump kubernetes to version 1.22.10.
+- [Azure] Bump flatcar to version 3139.2.1.
+- [AWS] Bump kubernetes to version 1.22.10.
+- [AWS] Bump flatcar to version 3139.2.2.
+- Bump etcd to 3.5.4.
+
 ## [9.4.0] - 2022-05-24
 
 ### Changed

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -130,7 +130,7 @@ variable "flatcar_linux_channel" {
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
   type        = string
-  default     = "3139.2.0"
+  default     = "3139.2.2"
 }
 
 variable "flatcar_ami_owner" {
@@ -145,7 +145,7 @@ variable "docker_registry" {
 
 variable "hyperkube_version" {
   type    = string
-  default = "1.21.11"
+  default = "1.22.10"
 }
 
 ### DNS ###

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -138,7 +138,7 @@ variable "flatcar_linux_channel" {
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
   type        = string
-  default     = "3139.2.0"
+  default     = "3139.2.1"
 }
 
 variable "vault_image_publisher" {
@@ -162,7 +162,7 @@ variable "docker_registry" {
 }
 variable "hyperkube_version" {
   type    = string
-  default = "1.21.11"
+  default = "1.22.10"
 }
 
 ### DNS ###

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -990,7 +990,7 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.4.18
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/etcd:v3.5.4
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       {{if eq .Provider "azure" }}EnvironmentFile=-/var/lib/etcd/master-id{{end}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1127 and https://github.com/giantswarm/roadmap/issues/1128
- [Azure] Bump flatcar to version 3139.2.1.
- [AWS] Bump kubernetes to version 1.22.10.
- [AWS] Bump flatcar to version 3139.2.2.
- Bump etcd to 3.5.4.