### PR TITLE
Add registry mirror setting for containerd.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enabled auditd on masters, workers and bastions.
+- Add registry mirror setting for containerd.
 
 ### Changed
 

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -128,6 +128,7 @@ locals {
     "DisableAPIFairness"           = var.disable_api_fairness
     "DockerCIDR"                   = var.docker_cidr
     "DockerRegistry"               = var.docker_registry
+    "DockerRegistryMirror"         = var.docker_registry_mirror
     "ETCDEndpoints"                = "https://etcd1.${var.base_domain}:2379,https://etcd2.${var.base_domain}:2379,https://etcd3.${var.base_domain}:2379"
     "ETCDInitialClusterMulti"      = "etcd1=https://etcd1.${var.base_domain}:2380,etcd2=https://etcd2.${var.base_domain}:2380,etcd3=https://etcd3.${var.base_domain}:2380"
     "ETCDInitialClusterSingle"     = "etcd1=https://etcd1.${var.base_domain}:2380"

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -143,6 +143,11 @@ variable "docker_registry" {
   default = "quay.io"
 }
 
+variable "docker_registry_mirror" {
+  type    = string
+  default = "giantswarm.azurecr.io"
+}
+
 variable "hyperkube_version" {
   type    = string
   default = "1.22.11"

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -150,6 +150,7 @@ locals {
     "DisableAPIFairness"       = var.disable_api_fairness
     "DockerCIDR"               = var.docker_cidr
     "DockerRegistry"           = var.docker_registry
+    "DockerRegistryMirror"     = var.docker_registry_mirror
     "ETCDInitialClusterMulti"  = "etcd1=https://etcd1.${var.base_domain}:2380,etcd2=https://etcd2.${var.base_domain}:2380,etcd3=https://etcd3.${var.base_domain}:2380"
     "ETCDInitialClusterSingle" = "etcd1=https://etcd1.${var.base_domain}:2380"
     "GSReleaseVersion"         = var.release_version

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -160,6 +160,12 @@ variable "docker_registry" {
   type    = string
   default = "quay.io"
 }
+
+variable "docker_registry_mirror" {
+  type    = string
+  default = "giantswarm.azurecr.io"
+}
+
 variable "hyperkube_version" {
   type    = string
   default = "1.22.11"

--- a/templates/files/conf/containerd-config.toml
+++ b/templates/files/conf/containerd-config.toml
@@ -34,3 +34,7 @@ runtime_type = "io.containerd.runc.v2"
 SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{.DockerRegistry}}/{{ .PodInfraImage }}"
+{{- if ne .DockerRegistryMirror "" }}
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+endpoint = ["{{.DockerRegistryMirror}}"]
+{{- end }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22678

Add containerd registry mirror for docker.io to avoid image pull errors