### PR TITLE
api server flags based on node size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automatically set `--max-requests-inflight`, `--max-mutating-requests-inflight` and resource limits to API Server's manifest based on node size.
+
 ## [13.1.0] - 2022-09-06
 
 ### Changed

--- a/templates/files/conf/setup-apiserver-environment
+++ b/templates/files/conf/setup-apiserver-environment
@@ -1,0 +1,16 @@
+#!/bin/bash
+env_file="/etc/apiserver-environment"
+
+cpus="$(grep -c ^processor /proc/cpuinfo)"
+memory="$(awk '/MemFree/ { printf "%d \n", $2/1024/1024 }' /proc/meminfo)"
+
+declare -i cpus
+declare -i memory
+
+dedicated=$((cpus * 3 / 4))
+
+echo "MAX_REQUESTS_INFLIGHT=$((dedicated * 200 * 2 / 3))" >$env_file
+echo "MAX_MUTATING_REQUESTS_INFLIGHT=$((dedicated * 200 * 1 / 3))" >>$env_file
+echo "CPU_LIMIT=${dedicated}" >>$env_file
+echo "MEMORY_LIMIT=$((memory * 3 / 4))Gi" >>$env_file
+

--- a/templates/files/manifests/k8s-api-server.yaml.tmpl
+++ b/templates/files/manifests/k8s-api-server.yaml.tmpl
@@ -64,11 +64,17 @@ spec:
       - --proxy-client-key-file=/etc/kubernetes/ssl/apiserver-key.pem
       {{- if .DisableAPIFairness  }}
       - --enable-priority-and-fairness=false
+      {{- else }}
+      - --max-requests-inflight=${MAX_REQUESTS_INFLIGHT}
+      - --max-mutating-requests-inflight=${MAX_MUTATING_REQUESTS_INFLIGHT}
       {{- end }}
       resources:
         requests:
           cpu: 300m
           memory: 300Mi
+        limits:
+          cpu: ${CPU_LIMIT}
+          memory: ${MEMORY_LIMIT}
       livenessProbe:
         tcpSocket:
           port: 443

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -353,7 +353,7 @@ storage:
         source: "data:text/plain;charset=utf-8;base64,{{ index .Files "manifests/k8s-api-healthz.yaml" }}"
 
 
-    - path: /etc/kubernetes/manifests/api-server.yaml
+    - path: /etc/kubernetes/manifest-templates/k8s-api-server.yaml.tmpl
       filesystem: root
       mode: 384
       user:
@@ -361,7 +361,7 @@ storage:
       group:
         id: 0
       contents:
-        source: "data:text/plain;charset=utf-8;base64,{{ index .Files "manifests/api-server.yaml" }}"
+        source: "data:text/plain;charset=utf-8;base64,{{ index .Files "manifests/k8s-api-server.yaml.tmpl" }}"
 
     - path: /etc/kubernetes/manifests/controller-manager.yaml
       filesystem: root
@@ -432,6 +432,12 @@ storage:
         id: 0
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{ index .Files "conf/confirm" }}"
+
+    - path: /opt/bin/setup-apiserver-environment
+      filesystem: root
+      mode: 0544
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/setup-apiserver-environment" }}"
 
     - path: /etc/ssh/sshd_config
       filesystem: root
@@ -678,6 +684,26 @@ systemd:
         $IMAGE \
         ash -c "cat /etc/kubernetes/config/kubelet.yaml.tmpl |envsubst >/etc/kubernetes/config/kubelet.yaml"
 
+      [Install]
+      WantedBy=multi-user.target
+  - name: k8s-setup-apiserver-manifest.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=k8s-setup-apiserver-manifest Service
+      After=docker.service
+      Requires=docker.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      TimeoutStartSec=0
+      Environment=IMAGE={{.DockerRegistry}}/giantswarm/alpine:3.16.1-envsubst
+      ExecStartPre=/opt/bin/setup-apiserver-environment
+      ExecStart=docker run --rm \
+        --env-file /etc/apiserver-environment \
+        -v /etc/kubernetes/:/etc/kubernetes/ \
+        $IMAGE \
+        ash -c "cat /etc/kubernetes/manifest-templates/k8s-api-server.yaml.tmpl |envsubst >/etc/kubernetes/manifests/k8s-api-server.yaml"
       [Install]
       WantedBy=multi-user.target
   - name: docker.service


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23532

Automatically set `--max-requests-inflight`, `--max-mutating-requests…-inflight` and resource limits to API Server's manifest based on node size.
