### PR TITLE
Change permission of etcd key file in order to make `etcd-kubernetes-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix leftover systemd unit used by azure CNI.
 
+### Changed
+
+- Change permission of etcd key file in order to make `etcd-kubernetes-resources-count-exporter` app to run with unprivileged user.
+
 ## [13.1.0] - 2022-09-06
 
 ### Changed

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -868,6 +868,8 @@ systemd:
           --ca-file=/etc/kubernetes/ssl/etcd/server-ca.pem); \
         done; \
         [ -z "$result" ] && echo "Failed to issue etcd certs." && exit 1 || echo "Successfully issued etcd certs.";'
+      ExecStartPost=/usr/bin/chown root:giantswarm /etc/kubernetes/ssl/etcd/server-key.pem
+      ExecStartPost=/usr/bin/chmod 640 /etc/kubernetes/ssl/etcd/server-key.pem
       ExecStartPost=/bin/cp /etc/kubernetes/ssl/etcd/server-crt.pem /etc/kubernetes/ssl/etcd/client-crt.pem
       ExecStartPost=/bin/cp /etc/kubernetes/ssl/etcd/server-ca.pem /etc/kubernetes/ssl/etcd/client-ca.pem
       ExecStartPost=/bin/cp /etc/kubernetes/ssl/etcd/server-key.pem /etc/kubernetes/ssl/etcd/client-key.pem


### PR DESCRIPTION
…resources-count-exporter` app to run with unprivileged user.

Towards: https://github.com/giantswarm/giantswarm/issues/23643