### PR TITLE
Use 'MemTotal' rather than 'MemFree' to get memory limit for api server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use 'MemTotal' rather than 'MemFree' to get memory limit for api server.
+
 ## [14.4.0] - 2022-10-13
 
 ### Changed

--- a/templates/files/conf/setup-apiserver-environment
+++ b/templates/files/conf/setup-apiserver-environment
@@ -2,7 +2,7 @@
 env_file="/etc/apiserver-environment"
 
 cpus="$(grep -c ^processor /proc/cpuinfo)"
-memory="$(awk '/MemFree/ { printf "%d \n", $2/1024/1024 }' /proc/meminfo)"
+memory="$(awk '/MemTotal/ { printf "%d \n", $2/1024/1024 }' /proc/meminfo)"
 
 declare -i cpus
 declare -i memory


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23831
api server's memory limit calculation was wrong.

![giphy](https://user-images.githubusercontent.com/868430/196639063-c43b0b54-b050-45f9-b005-a80e6daeffcc.gif)

