### PR TITLE
Apiserver requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump cilium to 0.5.0.
 - Make `--enable-priority-and-fairness` flag always explicit.
 - Set CPU and Memory requests for Api server.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `--enable-priority-and-fairness` flag always explicit.
+- Set CPU and Memory requests for Api server.
+
 ## [14.4.1] - 2022-10-19
 
 ### Fixed

--- a/templates/files/apps/common/cilium-app.yaml
+++ b/templates/files/apps/common/cilium-app.yaml
@@ -8,8 +8,6 @@ data:
     defaultPolicies:
       enabled: true
     egressMasqueradeInterfaces: eth0
-    eni:
-      enabled: false
     kubeProxyReplacement: strict
     k8sServiceHost: "{{ .APIInternalDomainName }}"
     k8sServicePort: "443"
@@ -89,4 +87,4 @@ spec:
     secret:
       name: ""
       namespace: ""
-  version: 0.4.0
+  version: 0.5.0

--- a/templates/files/conf/setup-apiserver-environment
+++ b/templates/files/conf/setup-apiserver-environment
@@ -13,4 +13,5 @@ echo "MAX_REQUESTS_INFLIGHT=$((dedicated * 200 * 2 / 3))" >$env_file
 echo "MAX_MUTATING_REQUESTS_INFLIGHT=$((dedicated * 200 * 1 / 3))" >>$env_file
 echo "CPU_LIMIT=${dedicated}" >>$env_file
 echo "MEMORY_LIMIT=$((memory * 3 / 4))Gi" >>$env_file
-
+echo "CPU_REQUEST=$((cpus / 2))" >>$env_file
+echo "MEMORY_REQUEST=$((memory / 2))Gi" >>$env_file

--- a/templates/files/manifests/k8s-api-server.yaml.tmpl
+++ b/templates/files/manifests/k8s-api-server.yaml.tmpl
@@ -62,16 +62,17 @@ spec:
       - --requestheader-username-headers=X-Remote-User
       - --proxy-client-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
       - --proxy-client-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+      - --max-requests-inflight=${MAX_REQUESTS_INFLIGHT}
+      - --max-mutating-requests-inflight=${MAX_MUTATING_REQUESTS_INFLIGHT}
       {{- if .DisableAPIFairness  }}
       - --enable-priority-and-fairness=false
       {{- else }}
-      - --max-requests-inflight=${MAX_REQUESTS_INFLIGHT}
-      - --max-mutating-requests-inflight=${MAX_MUTATING_REQUESTS_INFLIGHT}
+      - --enable-priority-and-fairness=true
       {{- end }}
       resources:
         requests:
-          cpu: 300m
-          memory: 300Mi
+          cpu: ${CPU_REQUEST}
+          memory: ${MEMORY_REQUEST}
         limits:
           cpu: ${CPU_LIMIT}
           memory: ${MEMORY_LIMIT}


### PR DESCRIPTION
Due to the memory and cpu limit calculation we introduced for the API server manifest, there is a big difference between memory/cpu limits and requests in the master nodes. That might lead to overallocation of nodes when other pods are scheduled on masters (thinking about prometheus).

this PR adds a calculated value for memory and CPU limit as well so the overallocation should be minimal.

It also bumps cilium to latest release