### PR TITLE
fix typo in journald unit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix journald systemd override for worker nodes
+
 ## [14.6.0] - 2022-10-28
 
 ### Changed

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -285,7 +285,7 @@ systemd:
     enabled: false
     mask: true
   - name: systemd-journald.service
-    dropin:
+    dropins:
       # Better restarts: infinite retries, with a small delay
       # Because it crashes when we have falco + audit rules
       - name: 10-override.conf


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23524

Same block of code in masters and workers, but a typo made it fail on workers :disappointed: 