### PR TITLE
bump k8s and flatcar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow scraping of `kube-scheduler` and `controller-manager` metrics.
 
+### Changed
+
+- Revert flatcar to 3227.2.1 to prevent filesystem hang bug (see https://github.com/giantswarm/giantswarm/issues/23831).
+- Bump kubernetes to 1.24.8.
+
 ## [14.6.2] - 2022-11-02
 
 ### Fixed

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -130,7 +130,7 @@ variable "flatcar_linux_channel" {
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
   type        = string
-  default     = "3227.2.3"
+  default     = "3227.2.1"
 }
 
 variable "flatcar_ami_owner" {
@@ -150,7 +150,7 @@ variable "docker_registry_mirror" {
 
 variable "hyperkube_version" {
   type    = string
-  default = "1.24.7"
+  default = "1.24.8"
 }
 
 ### DNS ###

--- a/platforms/azure/giantnetes/variables.tf
+++ b/platforms/azure/giantnetes/variables.tf
@@ -138,7 +138,7 @@ variable "flatcar_linux_channel" {
 variable "flatcar_linux_version" {
   description = "Flatcar linux version."
   type        = string
-  default     = "3227.2.3"
+  default     = "3227.2.1"
 }
 
 variable "vault_image_publisher" {
@@ -168,7 +168,7 @@ variable "docker_registry_mirror" {
 
 variable "hyperkube_version" {
   type    = string
-  default = "1.24.7"
+  default = "1.24.8"
 }
 
 variable "pod_infra_image" {


### PR DESCRIPTION
- Revert flatcar to 3227.2.1 to prevent filesystem hang bug (see https://github.com/giantswarm/giantswarm/issues/23831).
- Bump kubernetes to 1.24.8.