### PR TITLE
Add missing labels for scheduler and controller manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add missing labels for `kube-scheduler` and `controller-manager`.
+
+### Fixed
+
+- Fix `kube-scheduler` healthcheck.
+
 ## [14.7.0] - 2022-11-15
 
 ### Fixed

--- a/templates/files/manifests/controller-manager.yaml
+++ b/templates/files/manifests/controller-manager.yaml
@@ -1,10 +1,13 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: k8s-controller-manager
-  namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
+  labels:
+    component: kube-controller-manager
+    tier: control-plane
+  name: k8s-controller-manager
+  namespace: kube-system
 spec:
   hostNetwork: true
   priorityClassName: system-node-critical

--- a/templates/files/manifests/scheduler.yaml
+++ b/templates/files/manifests/scheduler.yaml
@@ -1,10 +1,13 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: k8s-scheduler
-  namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
+  labels:
+    component: kube-scheduler
+    tier: control-plane
+  name: k8s-scheduler
+  namespace: kube-system
 spec:
   hostNetwork: true
   priorityClassName: system-node-critical
@@ -29,7 +32,7 @@ spec:
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10257
+          port: 10259
           scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15


### PR DESCRIPTION
Working on installing the prometheus agent on Vintage MCs, I noticed that the scheduler and controller manager were missing labels set on default service monitors https://github.com/giantswarm/prometheus-meta-operator/pull/1094

This PR fixes that.

At the same time, I noticed that the scheduler healthcheck is actually checking for the life of the controller manager (using port 10257). I'm guessing both scheduler and controller-manager are running in the host network, which allowed this behavior.

This image is a call to port 10257 using kubectl port-forward on the k8s scheduler (see leader_election_status metric at the end)
![image](https://user-images.githubusercontent.com/2787548/206908118-b91a142b-f02e-4d1e-86cc-9d175fb83f74.png)
