### PR TITLE
Update psp-policies.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allowed the use of all seccomp profiles for components under the restricted podsecurity policy.
+- Set the default seccomp profile to runtime/default under the restricted podsecurity policy.
+
 ## [14.8.0] - 2022-12-13
 
 ### Added

--- a/templates/files/k8s-resource/psp-policies.yaml
+++ b/templates/files/k8s-resource/psp-policies.yaml
@@ -30,6 +30,9 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
 spec:
   privileged: false
   fsGroup:


### PR DESCRIPTION
allow all seccomp profiles in restricted and set runtime/default as default profile.