### PR TITLE
Add loki S3 bucket and permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add Loki s3 bucket and permissions.
+
 ## [14.10.0] - 2023-01-31
 
 ### Changed

--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -76,6 +76,28 @@ resource "aws_iam_role_policy" "master" {
     {
         "Effect": "Allow",
         "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
+            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki",
+            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki/*"
+        ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:GetAccessPoint",
+            "s3:GetAccountPublicAccessBlock",
+            "s3:ListAccessPoints"
+        ],
+        "Resource": "*"
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
           "ec2:AssignPrivateIpAddresses",
           "ec2:AttachNetworkInterface",
           "ec2:CreateNetworkInterface",

--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -76,28 +76,6 @@ resource "aws_iam_role_policy" "master" {
     {
         "Effect": "Allow",
         "Action": [
-            "s3:ListBucket",
-            "s3:PutObject",
-            "s3:GetObject",
-            "s3:DeleteObject" 
-        ],
-        "Resource": [
-            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki",
-            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki/*"
-        ]
-    },
-    {
-        "Effect": "Allow",
-        "Action": [
-            "s3:GetAccessPoint",
-            "s3:GetAccountPublicAccessBlock",
-            "s3:ListAccessPoints"
-        ],
-        "Resource": "*"
-    },
-    {
-        "Effect": "Allow",
-        "Action": [
           "ec2:AssignPrivateIpAddresses",
           "ec2:AttachNetworkInterface",
           "ec2:CreateNetworkInterface",

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -46,7 +46,7 @@ resource "aws_s3_bucket" "logging" {
 }
 
 resource "aws_s3_bucket" "loki" {
-  bucket        = "${var.aws_account}-${var.cluster_name}-g8s-loki"
+  bucket        = "${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki"
   acl           = "private"
   force_destroy = true
 
@@ -70,7 +70,7 @@ resource "aws_s3_bucket" "loki" {
   tags = merge(
     local.common_tags,
     map(
-      "Name", "${var.aws_account}-${var.cluster_name}-g8s-loki"
+      "Name", "${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki"
     )
   )
 }

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -45,6 +45,35 @@ resource "aws_s3_bucket" "logging" {
   )
 }
 
+resource "aws_s3_bucket" "loki" {
+  bucket        = "${var.aws_account}-${var.cluster_name}-g8s-loki"
+  force_destroy = true
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "ExpirationLogs"
+    enabled = true
+
+    expiration {
+      days = var.logs_expiration_days
+    }
+  }
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "${var.aws_account}-${var.cluster_name}-g8s-loki"
+    )
+  )
+}
+
 resource "aws_s3_bucket_policy" "access-logs-policy" {
   bucket = aws_s3_bucket.logging.id
 

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -47,6 +47,7 @@ resource "aws_s3_bucket" "logging" {
 
 resource "aws_s3_bucket" "loki" {
   bucket        = "${var.aws_account}-${var.cluster_name}-g8s-loki"
+  acl           = "private"
   force_destroy = true
 
   server_side_encryption_configuration {

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -46,7 +46,7 @@ resource "aws_s3_bucket" "logging" {
 }
 
 resource "aws_s3_bucket" "loki" {
-  bucket        = "${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki"
+  bucket        = "${var.cluster_name}-g8s-loki"
   acl           = "private"
   force_destroy = true
 
@@ -70,7 +70,7 @@ resource "aws_s3_bucket" "loki" {
   tags = merge(
     local.common_tags,
     map(
-      "Name", "${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki"
+      "Name", "${var.cluster_name}-g8s-loki"
     )
   )
 }

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -102,8 +102,8 @@ resource "aws_iam_role_policy" "worker" {
             "s3:DeleteObject" 
         ],
         "Resource": [
-            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki",
-            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki/*"
+            "arn:${var.arn_region}:s3:::${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki",
+            "arn:${var.arn_region}:s3:::${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki/*"
         ]
     },
     {

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -102,8 +102,8 @@ resource "aws_iam_role_policy" "worker" {
             "s3:DeleteObject" 
         ],
         "Resource": [
-            "arn:${var.arn_region}:s3:::${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki",
-            "arn:${var.arn_region}:s3:::${var.s3_bucket_prefix}${var.cluster_name}-g8s-loki/*"
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-loki",
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-loki/*"
         ]
     },
     {

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -96,6 +96,28 @@ resource "aws_iam_role_policy" "worker" {
     {
         "Effect": "Allow",
         "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
+            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki",
+            "arn:${var.arn_region}:s3:::${var.aws_account}-${var.cluster_name}-g8s-loki/*"
+        ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:GetAccessPoint",
+            "s3:GetAccountPublicAccessBlock",
+            "s3:ListAccessPoints"
+        ],
+        "Resource": "*"
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
           "ec2:AssignPrivateIpAddresses",
           "ec2:AttachNetworkInterface",
           "ec2:CreateNetworkInterface",


### PR DESCRIPTION
Enable loki monitoring with an S3 bucket and permission on the node instance profile

Towards https://github.com/giantswarm/roadmap/issues/1849