### PR TITLE
add permissions for mimir-ruler S3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Mimir-ruler S3 buckets permissions.
+
 ## [14.13.0] - 2023-04-13
 
 ### Added

--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -89,6 +89,19 @@ resource "aws_iam_role_policy" "master" {
     {
         "Effect": "Allow",
         "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir-ruler",
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir-ruler/*"
+        ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
           "ec2:AssignPrivateIpAddresses",
           "ec2:AttachNetworkInterface",
           "ec2:CreateNetworkInterface",

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -122,6 +122,19 @@ resource "aws_iam_role_policy" "worker" {
     {
         "Effect": "Allow",
         "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir-ruler",
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir-ruler/*"
+        ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
             "s3:GetAccessPoint",
             "s3:GetAccountPublicAccessBlock",
             "s3:ListAccessPoints"


### PR DESCRIPTION
Mimir needs a specific bucket for its `ruler` component. I already created the bucket on `gauss`, just need to add the permissions to the nodes.