### PR TITLE
add permissions for loki in v19 test bucket

### DIFF
--- a/modules/aws/master/master-iam.tf
+++ b/modules/aws/master/master-iam.tf
@@ -82,6 +82,19 @@ resource "aws_iam_role_policy" "master" {
             "s3:DeleteObject" 
         ],
         "Resource": [
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-loki-test-v19",
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-loki-test-v19/*"
+        ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
             "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir",
             "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir/*"
         ]

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -115,6 +115,19 @@ resource "aws_iam_role_policy" "worker" {
             "s3:DeleteObject" 
         ],
         "Resource": [
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-loki-test-v19",
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-loki-test-v19/*"
+        ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
             "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir",
             "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir/*"
         ]


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2368

We're testing Loki on v19 on a WC and thus need permissions for accessing the bucket created for this purpose.
This change will be reverted once tested.