### PR TITLE
Independent data retention variable for Loki S3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove CSIMigration feature flag (enabled by default with k8s 1.23).
 - Allow port 2112 on vault instance for vault-etcd-backups-exporter.
 
+### Changed
+
+- independent data retention variable for Loki S3 buckets
+
 ## [14.15.1] - 2023-05-29
 
 ### Changed

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -63,7 +63,7 @@ resource "aws_s3_bucket" "loki" {
     enabled = true
 
     expiration {
-      days = var.logs_expiration_days
+      days = var.loki_expiration_days
     }
   }
 

--- a/modules/aws/s3/variables.tf
+++ b/modules/aws/s3/variables.tf
@@ -10,6 +10,10 @@ variable "logs_expiration_days" {
   type = string
 }
 
+variable "loki_expiration_days" {
+  type = string
+}
+
 variable "s3_bucket_prefix" {
   type = string
 }

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -96,6 +96,7 @@ module "s3" {
   aws_account          = var.aws_account
   cluster_name         = var.cluster_name
   logs_expiration_days = var.logs_expiration_days
+  loki_expiration_days = var.loki_expiration_days
   s3_bucket_prefix     = var.s3_bucket_prefix
 }
 
@@ -331,7 +332,7 @@ module "worker" {
 module "vpn" {
   source = "../../../modules/aws/vpn"
 
-  additional_tags             = var.additional_tags
+  additional_tags = var.additional_tags
   # If aws_customer_gateway_id_0 is not set, no vpn resources will be created.
   aws_customer_gateway_id_0   = var.aws_customer_gateway_id_0
   aws_customer_gateway_id_1   = var.aws_customer_gateway_id_1

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -69,6 +69,12 @@ variable "logs_expiration_days" {
   default     = "365"
 }
 
+variable "loki_expiration_days" {
+  type        = string
+  description = "Number of days Loki data will be stored in logging bucket if not deleted by Loki compactor."
+  default     = "100"
+}
+
 variable "s3_bucket_prefix" {
   default = ""
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2366

Loki deletes most of its data, but may miss some. And I was not happy that our retention period was not Loki-specific.

Only thing before merging: I forgot how to actually test my branch on a test cluster :sweat_smile: 