### PR TITLE
nginx-ingress-controller: Improve requests and autoscaling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- nginx-ingress-controller: Improve requests and autoscaling. ([#715](https://github.com/giantswarm/giantnetes-terraform/pull/715))
+
 ## [14.16.0] - 2023-06-21
 
 ### Changed

--- a/templates/files/apps/common/ingress-controller-app.yaml
+++ b/templates/files/apps/common/ingress-controller-app.yaml
@@ -8,13 +8,15 @@ data:
     controller:
       allowSnippetAnnotations: true
       enableSSLChainCompletion: true
+      resources:
+        requests:
+          cpu: 1
+          memory: 350Mi
+      autoscaling:
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       service:
         type: NodePort
-    configmap:
-      use-forwarded-headers: "false"
-      {{- if eq .Provider "aws" }}
-      use-proxy-protocol: "true"
-      {{- end }}
     image:
       registry: {{ .DockerRegistry }}
 ---


### PR DESCRIPTION
Also remove defaults. `use-forwarded-headers` is `false` by default, `use-proxy-protocol` gets set to `true` by the chart when installed to AWS.