### PR TITLE
allow vault etcd exporter port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove CSIMigration feature flag (enabled by default with k8s 1.23).
+- Allow port 2112 on vault instance for vault-etcd-backups-exporter.
 
 ## [14.15.1] - 2023-05-29
 

--- a/modules/aws/vault/vault.tf
+++ b/modules/aws/vault/vault.tf
@@ -156,6 +156,14 @@ resource "aws_security_group" "vault" {
     cidr_blocks = concat(data.aws_subnet.worker_subnets.*.cidr_block,[var.aws_cni_cidr_block])
   }
 
+  # Allow vault-etcd-backups-exporter from worker nodes.
+  ingress {
+    from_port   = 2112
+    to_port     = 2112
+    protocol    = "tcp"
+    cidr_blocks = concat(data.aws_subnet.worker_subnets.*.cidr_block,[var.aws_cni_cidr_block])
+  }
+
   tags = merge(
     local.common_tags,
     map(


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/27314

we added a new exporter to the vault VM and need to open the port in order for it to be scrapable