### PR TITLE
Enable auditd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable auditd.
+
 ## [14.16.1] - 2023-07-04
 
 ### Changed

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -15,6 +15,11 @@ resource "aws_s3_bucket" "logging" {
   acl           = "log-delivery-write"
   force_destroy = true
 
+  logging {
+    target_bucket = "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
+    target_prefix = "self-logs/"
+  }
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -38,13 +43,6 @@ resource "aws_s3_bucket" "logging" {
       "Name", "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
     )
   )
-}
-
-resource "aws_s3_bucket_logging" "logging" {
-  bucket = aws_s3_bucket.logging.id
-
-  target_bucket = aws_s3_bucket.logging.id
-  target_prefix = "self-logs/"
 }
 
 resource "aws_s3_bucket" "loki" {
@@ -107,6 +105,11 @@ resource "aws_s3_bucket" "ignition" {
   acl           = "private"
   force_destroy = true
 
+  logging {
+    target_bucket = aws_s3_bucket.logging.id
+    target_prefix = "${var.s3_bucket_prefix}${var.cluster_name}-ignition-logs/"
+  }
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -121,13 +124,6 @@ resource "aws_s3_bucket" "ignition" {
       "Name", "${var.cluster_name}-ignition"
     )
   )
-}
-
-resource "aws_s3_bucket_logging" "ignition" {
-  bucket = aws_s3_bucket.ignition.id
-
-  target_bucket = aws_s3_bucket.logging.id
-  target_prefix = "${var.s3_bucket_prefix}${var.cluster_name}-ignition-logs/"
 }
 
 resource "aws_s3_bucket_policy" "ignition-policy" {

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -15,11 +15,6 @@ resource "aws_s3_bucket" "logging" {
   acl           = "log-delivery-write"
   force_destroy = true
 
-  logging {
-    target_bucket = "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
-    target_prefix = "self-logs/"
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -43,6 +38,13 @@ resource "aws_s3_bucket" "logging" {
       "Name", "${var.s3_bucket_prefix}${var.cluster_name}-access-logs"
     )
   )
+}
+
+resource "aws_s3_bucket_logging" "logging" {
+  bucket = aws_s3_bucket.logging.id
+
+  target_bucket = aws_s3_bucket.logging.id
+  target_prefix = "self-logs/"
 }
 
 resource "aws_s3_bucket" "loki" {
@@ -105,11 +107,6 @@ resource "aws_s3_bucket" "ignition" {
   acl           = "private"
   force_destroy = true
 
-  logging {
-    target_bucket = aws_s3_bucket.logging.id
-    target_prefix = "${var.s3_bucket_prefix}${var.cluster_name}-ignition-logs/"
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -124,6 +121,13 @@ resource "aws_s3_bucket" "ignition" {
       "Name", "${var.cluster_name}-ignition"
     )
   )
+}
+
+resource "aws_s3_bucket_logging" "ignition" {
+  bucket = aws_s3_bucket.ignition.id
+
+  target_bucket = aws_s3_bucket.logging.id
+  target_prefix = "${var.s3_bucket_prefix}${var.cluster_name}-ignition-logs/"
 }
 
 resource "aws_s3_bucket_policy" "ignition-policy" {

--- a/templates/bastion.yaml.tmpl
+++ b/templates/bastion.yaml.tmpl
@@ -130,6 +130,8 @@ systemd:
         [Install]
         WantedBy=multi-user.target
     {{ end }}
+    - name: auditd.service
+      enabled: true
 storage:
   files:
 

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1251,6 +1251,8 @@ systemd:
       ExecStart=/opt/install-debug-tools
       [Install]
       WantedBy=multi-user.target
+  - name: auditd.service
+    enabled: true
 {{ if .LogentriesEnabled }}
   - name: logentries.service
     enabled: true
@@ -1319,8 +1321,6 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 {{ end -}}
-  - name: auditd.service
-    enabled: true
 {{ if eq .Provider "aws" -}}
 networkd:
   units:

--- a/templates/master.yaml.tmpl
+++ b/templates/master.yaml.tmpl
@@ -1319,6 +1319,8 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 {{ end -}}
+  - name: auditd.service
+    enabled: true
 {{ if eq .Provider "aws" -}}
 networkd:
   units:

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -713,7 +713,8 @@ systemd:
         $KUBECTL label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=worker'
       [Install]
       WantedBy=multi-user.target
-
+  - name: auditd.service
+    enabled: true
 {{ if .LogentriesEnabled }}
   - name: logentries.service
     enabled: true
@@ -729,8 +730,6 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 {{ end }}
-  - name: auditd.service
-    enabled: true
 {{ if eq .Provider "aws" }}
 networkd:
   units:

--- a/templates/worker.yaml.tmpl
+++ b/templates/worker.yaml.tmpl
@@ -729,6 +729,8 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 {{ end }}
+  - name: auditd.service
+    enabled: true
 {{ if eq .Provider "aws" }}
 networkd:
   units:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24992

As seen here https://www.flatcar.org/docs/latest/setup/security/audit/#enabling-auditd it looks like we enabled the auditd rules but not the audit daemon which is actually needed to have audit logs in a file