### PR TITLE
Add tempo buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `cilium-app` to `0.12.0`.
 - Bump `coredns-app` to `1.18.1`.
 - Set `--quota-backend-bytes` flag to etcd.
+- Add Tempo s3 bucket and permissions.
+- Create mimir buckets.
 
 ## [14.18.0] - 2023-08-03
 

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket" "loki" {
   }
 
   lifecycle_rule {
-    id      = "ExpirationLogs"
+    id      = "Expiration"
     enabled = true
 
     expiration {
@@ -71,6 +71,87 @@ resource "aws_s3_bucket" "loki" {
     local.common_tags,
     map(
       "Name", "${var.cluster_name}-g8s-loki"
+    )
+  )
+}
+
+resource "aws_s3_bucket" "mimir" {
+  bucket        = "${var.cluster_name}-g8s-mimir"
+  acl           = "private"
+  force_destroy = true
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "Expiration"
+    enabled = true
+
+    expiration {
+      days = var.mimir_expiration_days
+    }
+  }
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-g8s-mimir"
+    )
+  )
+}
+
+resource "aws_s3_bucket" "mimir-ruler" {
+  bucket        = "${var.cluster_name}-g8s--ruler"
+  acl           = "private"
+  force_destroy = true
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-g8s-mimir-ruler"
+    )
+  )
+}
+
+resource "aws_s3_bucket" "tempo" {
+  bucket        = "${var.cluster_name}-g8s-tempo"
+  acl           = "private"
+  force_destroy = true
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expiration"
+    enabled = true
+
+    expiration {
+      days = var.tempo_expiration_days
+    }
+  }
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "${var.cluster_name}-g8s-tempo"
     )
   )
 }

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -140,7 +140,7 @@ resource "aws_s3_bucket" "tempo" {
   }
 
   lifecycle_rule {
-    id      = "expiration"
+    id      = "Expiration"
     enabled = true
 
     expiration {

--- a/modules/aws/s3/s3.tf
+++ b/modules/aws/s3/s3.tf
@@ -106,7 +106,7 @@ resource "aws_s3_bucket" "mimir" {
 }
 
 resource "aws_s3_bucket" "mimir-ruler" {
-  bucket        = "${var.cluster_name}-g8s--ruler"
+  bucket        = "${var.cluster_name}-g8s-mimir-ruler"
   acl           = "private"
   force_destroy = true
 

--- a/modules/aws/s3/variables.tf
+++ b/modules/aws/s3/variables.tf
@@ -14,6 +14,14 @@ variable "loki_expiration_days" {
   type = string
 }
 
+variable "mimir_expiration_days" {
+  type = string
+}
+
+variable "tempo_expiration_days" {
+  type = string
+}
+
 variable "s3_bucket_prefix" {
   type = string
 }

--- a/modules/aws/worker-asg/worker-iam.tf
+++ b/modules/aws/worker-asg/worker-iam.tf
@@ -132,6 +132,19 @@ resource "aws_iam_role_policy" "worker" {
             "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-mimir-ruler/*"
         ]
     },
+        {
+        "Effect": "Allow",
+        "Action": [
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject" 
+        ],
+        "Resource": [
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-tempo",
+            "arn:${var.arn_region}:s3:::${var.cluster_name}-g8s-tempo/*"
+        ]
+    },
     {
         "Effect": "Allow",
         "Action": [

--- a/platforms/aws/giantnetes/main.tf
+++ b/platforms/aws/giantnetes/main.tf
@@ -97,6 +97,8 @@ module "s3" {
   cluster_name         = var.cluster_name
   logs_expiration_days = var.logs_expiration_days
   loki_expiration_days = var.loki_expiration_days
+  mimir_expiration_days = var.mimir_expiration_days
+  tempo_expiration_days = var.tempo_expiration_days
   s3_bucket_prefix     = var.s3_bucket_prefix
 }
 

--- a/platforms/aws/giantnetes/variables.tf
+++ b/platforms/aws/giantnetes/variables.tf
@@ -75,6 +75,18 @@ variable "loki_expiration_days" {
   default     = "100"
 }
 
+variable "mimir_expiration_days" {
+  type        = string
+  description = "Number of days Mimir data will be stored in mimir bucket if not deleted by Mimir compactor."
+  default     = "60"
+}
+
+variable "tempo_expiration_days" {
+  type        = string
+  description = "Number of days Tempo data will be stored in trace bucket if not deleted by Tempo compactor."
+  default     = "60"
+}
+
 variable "s3_bucket_prefix" {
   default = ""
 }


### PR DESCRIPTION
This PR adds tempo and mimir bucket on vintage installations. This is needed so we can try out tempo and migrate to mimir in a bit