### PR TITLE
Update ingress-nginx on vintage MCs

### DIFF
--- a/templates/files/apps/common/nginx-ingress-controller-app.yaml
+++ b/templates/files/apps/common/nginx-ingress-controller-app.yaml
@@ -6,6 +6,8 @@ metadata:
 data:
   values: |
     controller:
+      image:
+        tag: "v1.11.2"
       allowSnippetAnnotations: true
       enableSSLChainCompletion: true
       resources:


### PR DESCRIPTION
Update the ingress-nginx container image tag to use v1.11.2 on vintage MCs

Towards https://github.com/giantswarm/adidas/issues/1298

The change in here already has been applied to some aws vintage management clusters